### PR TITLE
Add basic Svelte UI

### DIFF
--- a/src/lib/stores/questions.ts
+++ b/src/lib/stores/questions.ts
@@ -1,0 +1,13 @@
+import { writable } from 'svelte/store';
+
+export interface Question {
+  id: number;
+  type: 'single' | 'multiple' | 'short';
+  question: string;
+  options?: Record<string, string>;
+  answer: string | string[];
+  source?: string;
+  subject?: string;
+}
+
+export const questions = writable<Question[]>([]);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,156 +1,22 @@
 <script lang="ts">
-  import { invoke } from "@tauri-apps/api/core";
-
-  let name = $state("");
-  let greetMsg = $state("");
-
-  async function greet(event: Event) {
-    event.preventDefault();
-    // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-    greetMsg = await invoke("greet", { name });
-  }
 </script>
 
 <main class="container">
-  <h1>Welcome to Tauri + Svelte</h1>
-
-  <div class="row">
-    <a href="https://vitejs.dev" target="_blank">
-      <img src="/vite.svg" class="logo vite" alt="Vite Logo" />
-    </a>
-    <a href="https://tauri.app" target="_blank">
-      <img src="/tauri.svg" class="logo tauri" alt="Tauri Logo" />
-    </a>
-    <a href="https://kit.svelte.dev" target="_blank">
-      <img src="/svelte.svg" class="logo svelte-kit" alt="SvelteKit Logo" />
-    </a>
-  </div>
-  <p>Click on the Tauri, Vite, and SvelteKit logos to learn more.</p>
-
-  <form class="row" onsubmit={greet}>
-    <input id="greet-input" placeholder="Enter a name..." bind:value={name} />
-    <button type="submit">Greet</button>
-  </form>
-  <p>{greetMsg}</p>
+  <h1>Qastella Exam App</h1>
+  <nav>
+    <a href="/import">Import Questions</a>
+    <a href="/questions">Question List</a>
+    <a href="/exam">Start Exam</a>
+  </nav>
 </main>
 
 <style>
-.logo.vite:hover {
-  filter: drop-shadow(0 0 2em #747bff);
-}
-
-.logo.svelte-kit:hover {
-  filter: drop-shadow(0 0 2em #ff3e00);
-}
-
-:root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
-
-  color: #0f0f0f;
-  background-color: #f6f6f6;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
-}
-
 .container {
-  margin: 0;
-  padding-top: 10vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+  padding: 2rem;
   text-align: center;
 }
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: 0.75s;
+nav a {
+  margin: 0 1rem;
+  font-size: 1.2rem;
 }
-
-.logo.tauri:hover {
-  filter: drop-shadow(0 0 2em #24c8db);
-}
-
-.row {
-  display: flex;
-  justify-content: center;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-
-a:hover {
-  color: #535bf2;
-}
-
-h1 {
-  text-align: center;
-}
-
-input,
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
-  transition: border-color 0.25s;
-  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
-}
-
-button {
-  cursor: pointer;
-}
-
-button:hover {
-  border-color: #396cd8;
-}
-button:active {
-  border-color: #396cd8;
-  background-color: #e8e8e8;
-}
-
-input,
-button {
-  outline: none;
-}
-
-#greet-input {
-  margin-right: 5px;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    color: #f6f6f6;
-    background-color: #2f2f2f;
-  }
-
-  a:hover {
-    color: #24c8db;
-  }
-
-  input,
-  button {
-    color: #ffffff;
-    background-color: #0f0f0f98;
-  }
-  button:active {
-    background-color: #0f0f0f69;
-  }
-}
-
 </style>

--- a/src/routes/exam/+page.svelte
+++ b/src/routes/exam/+page.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { questions } from '$lib/stores/questions';
+
+  let answers: Record<number, string> = {};
+  let finished = false;
+  let score = 0;
+
+  function submit() {
+    score = 0;
+    $questions.forEach((q) => {
+      if (answers[q.id] && answers[q.id] === q.answer) {
+        score += 1;
+      }
+    });
+    finished = true;
+  }
+</script>
+
+<h1>Mock Exam</h1>
+{#if $questions.length === 0}
+<p>No questions available. <a href="/import">Import a file</a>.</p>
+{:else}
+<form on:submit|preventDefault={submit}>
+  {#each $questions as q (q.id)}
+  <div class="question">
+    <p>{q.question}</p>
+    {#if q.options}
+      {#each Object.entries(q.options) as [key, text]}
+        <label>
+          <input type="radio" name="q-{q.id}" value={key} bind:group={answers[q.id]} />
+          {key}. {text}
+        </label>
+      {/each}
+    {/if}
+  </div>
+  {/each}
+  <button type="submit">Submit</button>
+</form>
+{/if}
+
+{#if finished}
+<p>Score: {score} / {$questions.length}</p>
+{/if}
+
+<style>
+.question {
+  margin-bottom: 1em;
+}
+label {
+  display: block;
+}
+</style>

--- a/src/routes/import/+page.svelte
+++ b/src/routes/import/+page.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { questions, type Question } from '$lib/stores/questions';
+
+  function handleFile(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result as string);
+        if (Array.isArray(data.questions)) {
+          const list: Question[] = data.questions.map((q: any, i: number) => ({
+            id: q.id ?? i + 1,
+            type: q.type ?? 'single',
+            question: q.question,
+            options: q.options,
+            answer: q.answer,
+            source: data.source,
+            subject: data.subject,
+          }));
+          questions.set(list);
+        }
+      } catch (e) {
+        console.error('Failed to parse', e);
+      }
+    };
+    reader.readAsText(file);
+  }
+</script>
+
+<h1>Import Questions</h1>
+<input type="file" accept="application/json" on:change={handleFile} />
+<p>Load a JSON file with the following structure:</p>
+<pre>{@html `{
+  "source": "110年醫學四",
+  "subject": "生理學",
+  "questions": [
+    { "id": 1, "type": "single", "question": "...", "options": {"A":"..."}, "answer": "A" }
+  ]
+}`}</pre>
+
+<a href="/questions">View Questions</a>
+
+<style>
+pre {
+  background-color: #eee;
+  padding: 1em;
+}
+</style>

--- a/src/routes/questions/+page.svelte
+++ b/src/routes/questions/+page.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { questions } from '$lib/stores/questions';
+</script>
+
+<h1>Question List</h1>
+{#if $questions.length === 0}
+<p>No questions loaded. <a href="/import">Import a file</a>.</p>
+{:else}
+  <ol>
+  {#each $questions as q}
+    <li>
+      <p>{q.question}</p>
+      {#if q.options}
+        <ul>
+        {#each Object.entries(q.options) as [key, text]}
+          <li>{key}. {text}</li>
+        {/each}
+        </ul>
+      {/if}
+      <p><strong>Answer:</strong> {Array.isArray(q.answer) ? q.answer.join(', ') : q.answer}</p>
+    </li>
+  {/each}
+  </ol>
+{/if}


### PR DESCRIPTION
## Summary
- implement question store
- add pages for import, list and exam
- simplify home page navigation
- remove unused import in exam page

## Testing
- `pnpm install`
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_6873dd2933a483279e7fa7d107917bce