### PR TITLE
Add exam history and settings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,7 +65,10 @@ fn resolve_path(
 ) -> Result<PathBuf, String> {
     if let Some(d) = dir {
         let mut p = PathBuf::from(d);
-        if p.is_dir() {
+        // Treat the provided value as a directory path. Even if it does not yet
+        // exist, join the desired file name so we read/write to
+        // `<dir>/<file>` rather than the directory itself.
+        if p.is_dir() || p.extension().is_none() {
             p.push(file);
         }
         Ok(p)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,8 @@ struct RQuestion {
     question: String,
     options: Option<HashMap<String, String>>,
     answer: Value,
+    source: Option<String>,
+    subject: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -36,7 +38,14 @@ fn sample_questions() -> Vec<RQuestion> {
     let mut opts = HashMap::new();
     opts.insert("A".into(), "Yes".into());
     opts.insert("B".into(), "No".into());
-    vec![RQuestion { id: 1, question: "Example?".into(), options: Some(opts), answer: Value::String("A".into()) }]
+    vec![RQuestion {
+        id: 1,
+        question: "Example?".into(),
+        options: Some(opts),
+        answer: Value::String("A".into()),
+        source: Some("Sample".into()),
+        subject: Some("General".into()),
+    }]
 }
 
 #[tauri::command]
@@ -49,7 +58,11 @@ fn default_data_dir(app_handle: tauri::AppHandle) -> Result<String, String> {
         .to_string())
 }
 
-fn resolve_path(app_handle: &tauri::AppHandle, dir: Option<String>, file: &str) -> Result<PathBuf, String> {
+fn resolve_path(
+    app_handle: &tauri::AppHandle,
+    dir: Option<String>,
+    file: &str,
+) -> Result<PathBuf, String> {
     if let Some(d) = dir {
         let mut p = PathBuf::from(d);
         if p.is_dir() {
@@ -66,7 +79,10 @@ fn resolve_path(app_handle: &tauri::AppHandle, dir: Option<String>, file: &str) 
 }
 
 #[tauri::command]
-fn load_questions(app_handle: tauri::AppHandle, dir: Option<String>) -> Result<Vec<RQuestion>, String> {
+fn load_questions(
+    app_handle: tauri::AppHandle,
+    dir: Option<String>,
+) -> Result<Vec<RQuestion>, String> {
     let path = resolve_path(&app_handle, dir, "question_bank.json")?;
     match fs::read_to_string(path) {
         Ok(content) => serde_json::from_str(&content).map_err(|e| e.to_string()),
@@ -75,7 +91,11 @@ fn load_questions(app_handle: tauri::AppHandle, dir: Option<String>) -> Result<V
 }
 
 #[tauri::command]
-fn save_questions(app_handle: tauri::AppHandle, dir: Option<String>, questions: Vec<RQuestion>) -> Result<(), String> {
+fn save_questions(
+    app_handle: tauri::AppHandle,
+    dir: Option<String>,
+    questions: Vec<RQuestion>,
+) -> Result<(), String> {
     let path = resolve_path(&app_handle, dir, "question_bank.json")?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
@@ -86,7 +106,10 @@ fn save_questions(app_handle: tauri::AppHandle, dir: Option<String>, questions: 
 }
 
 #[tauri::command]
-fn load_history(app_handle: tauri::AppHandle, dir: Option<String>) -> Result<Vec<RExamResult>, String> {
+fn load_history(
+    app_handle: tauri::AppHandle,
+    dir: Option<String>,
+) -> Result<Vec<RExamResult>, String> {
     let path = resolve_path(&app_handle, dir, "history.json")?;
     match fs::read_to_string(path) {
         Ok(content) => serde_json::from_str(&content).map_err(|e| e.to_string()),
@@ -95,7 +118,11 @@ fn load_history(app_handle: tauri::AppHandle, dir: Option<String>) -> Result<Vec
 }
 
 #[tauri::command]
-fn save_history(app_handle: tauri::AppHandle, dir: Option<String>, history: Vec<RExamResult>) -> Result<(), String> {
+fn save_history(
+    app_handle: tauri::AppHandle,
+    dir: Option<String>,
+    history: Vec<RExamResult>,
+) -> Result<(), String> {
     let path = resolve_path(&app_handle, dir, "history.json")?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{collections::HashMap, fs};
+use std::{collections::HashMap, fs, path::PathBuf};
 use tauri::Manager;
 
 #[tauri::command]
@@ -17,6 +17,20 @@ struct RQuestion {
     answer: Value,
 }
 
+#[derive(Serialize, Deserialize)]
+struct RAnswerRecord {
+    question: RQuestion,
+    answer: Value,
+    correct: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct RExamResult {
+    records: Vec<RAnswerRecord>,
+    elapsed: u64,
+    timestamp: String,
+}
+
 #[tauri::command]
 fn sample_questions() -> Vec<RQuestion> {
     let mut opts = HashMap::new();
@@ -26,16 +40,67 @@ fn sample_questions() -> Vec<RQuestion> {
 }
 
 #[tauri::command]
-fn save_questions(app_handle: tauri::AppHandle, questions: Vec<RQuestion>) -> Result<(), String> {
-    let path = app_handle
+fn default_data_dir(app_handle: tauri::AppHandle) -> Result<String, String> {
+    Ok(app_handle
         .path()
         .app_data_dir()
         .map_err(|e| e.to_string())?
-        .join("question_bank.json");
-    if let Some(dir) = path.parent() {
-        fs::create_dir_all(dir).map_err(|e| e.to_string())?;
+        .to_string_lossy()
+        .to_string())
+}
+
+fn resolve_path(app_handle: &tauri::AppHandle, dir: Option<String>, file: &str) -> Result<PathBuf, String> {
+    if let Some(d) = dir {
+        let mut p = PathBuf::from(d);
+        if p.is_dir() {
+            p.push(file);
+        }
+        Ok(p)
+    } else {
+        Ok(app_handle
+            .path()
+            .app_data_dir()
+            .map_err(|e| e.to_string())?
+            .join(file))
+    }
+}
+
+#[tauri::command]
+fn load_questions(app_handle: tauri::AppHandle, dir: Option<String>) -> Result<Vec<RQuestion>, String> {
+    let path = resolve_path(&app_handle, dir, "question_bank.json")?;
+    match fs::read_to_string(path) {
+        Ok(content) => serde_json::from_str(&content).map_err(|e| e.to_string()),
+        Err(_) => Ok(Vec::new()),
+    }
+}
+
+#[tauri::command]
+fn save_questions(app_handle: tauri::AppHandle, dir: Option<String>, questions: Vec<RQuestion>) -> Result<(), String> {
+    let path = resolve_path(&app_handle, dir, "question_bank.json")?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
     let data = serde_json::to_vec_pretty(&questions).map_err(|e| e.to_string())?;
+    fs::write(path, data).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[tauri::command]
+fn load_history(app_handle: tauri::AppHandle, dir: Option<String>) -> Result<Vec<RExamResult>, String> {
+    let path = resolve_path(&app_handle, dir, "history.json")?;
+    match fs::read_to_string(path) {
+        Ok(content) => serde_json::from_str(&content).map_err(|e| e.to_string()),
+        Err(_) => Ok(Vec::new()),
+    }
+}
+
+#[tauri::command]
+fn save_history(app_handle: tauri::AppHandle, dir: Option<String>, history: Vec<RExamResult>) -> Result<(), String> {
+    let path = resolve_path(&app_handle, dir, "history.json")?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let data = serde_json::to_vec_pretty(&history).map_err(|e| e.to_string())?;
     fs::write(path, data).map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -44,7 +109,15 @@ fn save_questions(app_handle: tauri::AppHandle, questions: Vec<RQuestion>) -> Re
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![greet, sample_questions, save_questions])
+        .invoke_handler(tauri::generate_handler![
+            greet,
+            sample_questions,
+            default_data_dir,
+            load_questions,
+            save_questions,
+            load_history,
+            save_history
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/lib/stores/exam.ts
+++ b/src/lib/stores/exam.ts
@@ -1,0 +1,5 @@
+import { writable } from 'svelte/store';
+import type { Question } from './questions';
+
+export const examQuestions = writable<Question[]>([]);
+

--- a/src/lib/stores/questions.ts
+++ b/src/lib/stores/questions.ts
@@ -1,5 +1,6 @@
 import { writable, get } from 'svelte/store';
 import { invoke } from '@tauri-apps/api/core';
+import { dataDir } from './settings';
 
 export interface Question {
   id: number;
@@ -15,5 +16,13 @@ export const questions = writable<Question[]>([]);
 
 export async function saveQuestionBank() {
   const list = get(questions);
-  await invoke('save_questions', { questions: list });
+  const dir = get(dataDir);
+  await invoke('save_questions', { dir, questions: list });
 }
+
+export async function loadQuestionBank() {
+  const dir = get(dataDir);
+  const data = await invoke('load_questions', { dir });
+  questions.set((data as Question[]) ?? []);
+}
+

--- a/src/lib/stores/results.ts
+++ b/src/lib/stores/results.ts
@@ -1,5 +1,7 @@
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 import type { Question } from './questions';
+import { invoke } from '@tauri-apps/api/core';
+import { dataDir } from './settings';
 
 export interface AnswerRecord {
   question: Question;
@@ -15,4 +17,29 @@ export interface ExamResult {
 export const lastResult = writable<ExamResult | null>(null);
 export const attemptCount = writable(0);
 export const correctTotal = writable(0);
+
+export interface HistoryEntry {
+  timestamp: string;
+  result: ExamResult;
+}
+
+export const history = writable<HistoryEntry[]>([]);
+
+export async function loadHistory() {
+  const dir = get(dataDir);
+  const data = await invoke('load_history', { dir });
+  history.set((data as HistoryEntry[]) ?? []);
+}
+
+export async function saveHistory() {
+  const dir = get(dataDir);
+  const list = get(history);
+  await invoke('save_history', { dir, history: list });
+}
+
+export function addResultToHistory(res: ExamResult) {
+  history.update((list) => [...list, { timestamp: new Date().toISOString(), result: res }]);
+  saveHistory();
+}
+
 

--- a/src/lib/stores/results.ts
+++ b/src/lib/stores/results.ts
@@ -18,17 +18,16 @@ export const lastResult = writable<ExamResult | null>(null);
 export const attemptCount = writable(0);
 export const correctTotal = writable(0);
 
-export interface HistoryEntry {
+export interface TimedExamResult extends ExamResult {
   timestamp: string;
-  result: ExamResult;
 }
 
-export const history = writable<HistoryEntry[]>([]);
+export const history = writable<TimedExamResult[]>([]);
 
 export async function loadHistory() {
   const dir = get(dataDir);
   const data = await invoke('load_history', { dir });
-  history.set((data as HistoryEntry[]) ?? []);
+  history.set((data as TimedExamResult[]) ?? []);
 }
 
 export async function saveHistory() {
@@ -38,7 +37,7 @@ export async function saveHistory() {
 }
 
 export function addResultToHistory(res: ExamResult) {
-  history.update((list) => [...list, { timestamp: new Date().toISOString(), result: res }]);
+  history.update((list) => [...list, { ...res, timestamp: new Date().toISOString() }]);
   saveHistory();
 }
 

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,0 +1,15 @@
+import { writable } from 'svelte/store';
+import { invoke } from '@tauri-apps/api/core';
+
+export const dataDir = writable('');
+
+export async function initSettings() {
+  const dir = (await invoke('default_data_dir')) as string;
+  const saved = typeof localStorage !== 'undefined' ? localStorage.getItem('dataDir') : null;
+  dataDir.set(saved || dir);
+  dataDir.subscribe((v) => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('dataDir', v);
+    }
+  });
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,12 +1,31 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { initSettings } from '$lib/stores/settings';
-  import { loadQuestionBank } from '$lib/stores/questions';
-  import { loadHistory } from '$lib/stores/results';
+  import { loadQuestionBank, saveQuestionBank } from '$lib/stores/questions';
+  import { loadHistory, saveHistory } from '$lib/stores/results';
+  import { getCurrentWindow } from '@tauri-apps/api/window';
 
-  onMount(async () => {
-    await initSettings();
-    await Promise.all([loadQuestionBank(), loadHistory()]);
+  onMount(() => {
+    (async () => {
+      await initSettings();
+      await Promise.all([loadQuestionBank(), loadHistory()]);
+    })();
+
+    const saveAll = () => {
+      saveQuestionBank();
+      saveHistory();
+    };
+
+    const win = getCurrentWindow();
+    window.addEventListener('beforeunload', saveAll);
+    win.listen('tauri://close-requested', () => {
+      saveAll();
+      win.close();
+    });
+
+    return () => {
+      window.removeEventListener('beforeunload', saveAll);
+    };
   });
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,22 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+  import { initSettings } from '$lib/stores/settings';
+  import { loadQuestionBank } from '$lib/stores/questions';
+  import { loadHistory } from '$lib/stores/results';
+
+  onMount(async () => {
+    await initSettings();
+    await Promise.all([loadQuestionBank(), loadHistory()]);
+  });
 </script>
 
 <nav class="main-nav">
   <a href="/">Dashboard</a>
   <a href="/exam-config">Mock Exam</a>
-  <a href="/import-exam">Import Exam</a>
+  <a href="/import-questionbank">Import Question Bank</a>
   <a href="/question-bank">Question Bank</a>
+  <a href="/history">History</a>
+  <a href="/settings">Settings</a>
 </nav>
 
 <slot />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,7 +28,7 @@
   {/if}
   <nav class="quick">
     <a href="/exam-config">Start Mock Exam</a>
-    <a href="/import-exam">Import Exam</a>
+    <a href="/import-questionbank">Import Question Bank</a>
     <a href="/question-bank">Manage Bank</a>
   </nav>
 </main>

--- a/src/routes/exam-config/+page.svelte
+++ b/src/routes/exam-config/+page.svelte
@@ -1,11 +1,25 @@
 <script lang="ts">
   import { questions } from '$lib/stores/questions';
+  import { examQuestions } from '$lib/stores/exam';
   import { goto } from '$app/navigation';
-  import { writable } from 'svelte/store';
+  import { writable, derived, get } from 'svelte/store';
 
   const count = writable(10);
+  const subject = writable('');
+  const source = writable('');
+
+  const subjects = derived(questions, qs => Array.from(new Set(qs.map(q => q.subject).filter(Boolean))) as string[]);
+  const sources = derived(questions, qs => Array.from(new Set(qs.map(q => q.source).filter(Boolean))) as string[]);
 
   function start() {
+    const subj = get(subject);
+    const src = get(source);
+    const cnt = get(count);
+    const list = get(questions).filter(
+      (q) => (!subj || q.subject === subj) && (!src || q.source === src)
+    );
+    const shuffled = [...list].sort(() => Math.random() - 0.5).slice(0, cnt);
+    examQuestions.set(shuffled);
     goto('/mock-exam');
   }
 </script>
@@ -15,5 +29,23 @@
 <label>
   Question count:
   <input type="number" min="1" max={$questions.length} bind:value={$count} />
+</label>
+<label>
+  Subject:
+  <select bind:value={$subject}>
+    <option value="">All</option>
+    {#each $subjects as s}
+      <option value={s}>{s}</option>
+    {/each}
+  </select>
+</label>
+<label>
+  Source:
+  <select bind:value={$source}>
+    <option value="">All</option>
+    {#each $sources as s}
+      <option value={s}>{s}</option>
+    {/each}
+  </select>
 </label>
 <button on:click={start}>Start</button>

--- a/src/routes/exam-result/+page.svelte
+++ b/src/routes/exam-result/+page.svelte
@@ -5,14 +5,7 @@
 <h1>Exam Result</h1>
 {#if $lastResult}
   <p>Score: {$lastResult.records.filter(r => r.correct).length} / {$lastResult.records.length}</p>
-  <ul>
-    {#each $lastResult.records as rec}
-      <li>
-        {rec.question.question} - {rec.correct ? '✔' : '✖'} (your answer: {rec.answer})
-      </li>
-    {/each}
-  </ul>
-  <a href="/review">Review Wrong Answers</a>
+  <a href="/review">Review Exam</a>
 {:else}
   <p>No result available.</p>
 {/if}

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { history } from '$lib/stores/results';
+</script>
+
+<h1>History</h1>
+{#if $history.length === 0}
+  <p>No exam history.</p>
+{:else}
+  <ul>
+    {#each $history as item}
+      <li>
+        {new Date(item.timestamp).toLocaleString()} -
+        {item.result.records.filter(r => r.correct).length}/{item.result.records.length}
+      </li>
+    {/each}
+  </ul>
+{/if}
+

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -7,12 +7,10 @@
   <p>No exam history.</p>
 {:else}
   <ul>
-    {#each $history as item}
+    {#each $history as item, i}
       <li>
-        {new Date(item.timestamp).toLocaleString()} -
-        {item.result.records.filter(r => r.correct).length}/{item.result.records.length}
+        <a href={`/review/${i}`}>{new Date(item.timestamp).toLocaleString()} - {item.result.records.filter(r => r.correct).length}/{item.result.records.length}</a>
       </li>
     {/each}
   </ul>
 {/if}
-

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -9,7 +9,7 @@
   <ul>
     {#each $history as item, i}
       <li>
-        <a href={`/review/${i}`}>{new Date(item.timestamp).toLocaleString()} - {item.result.records.filter(r => r.correct).length}/{item.result.records.length}</a>
+        <a href={`/review/${i}`}>{new Date(item.timestamp).toLocaleString()} - {item.records.filter(r => r.correct).length}/{item.records.length}</a>
       </li>
     {/each}
   </ul>

--- a/src/routes/import-questionbank/+page.svelte
+++ b/src/routes/import-questionbank/+page.svelte
@@ -11,16 +11,19 @@
       try {
         const data = JSON.parse(reader.result as string);
         if (Array.isArray(data.questions)) {
-          const list: Question[] = data.questions.map((q: any, i: number) => ({
-            id: q.id ?? i + 1,
-            type: q.type ?? 'single',
-            question: q.question,
-            options: q.options,
-            answer: q.answer,
-            source: data.source,
-            subject: data.subject,
-          }));
-          questions.set(list);
+          questions.update((existing) => {
+            const start = Math.max(0, ...existing.map((q) => q.id)) + 1;
+            const added: Question[] = data.questions.map((q: any, i: number) => ({
+              id: q.id ?? start + i,
+              type: q.type ?? 'single',
+              question: q.question,
+              options: q.options,
+              answer: q.answer,
+              source: data.source,
+              subject: data.subject,
+            }));
+            return [...existing, ...added];
+          });
         }
       } catch (e) {
         console.error('Failed to parse', e);

--- a/src/routes/import-questionbank/+page.svelte
+++ b/src/routes/import-questionbank/+page.svelte
@@ -35,7 +35,7 @@
   }
 </script>
 
-<h1>Import Exam</h1>
+<h1>Import Question Bank</h1>
 <input type="file" accept="application/json" on:change={handleFile} />
 <button on:click={loadSample}>Load Sample Questions</button>
 <p>Load a JSON file with the following structure:</p>

--- a/src/routes/mock-exam/+page.svelte
+++ b/src/routes/mock-exam/+page.svelte
@@ -1,32 +1,33 @@
   <script lang="ts">
     import { goto } from '$app/navigation';
-    import { questions } from '$lib/stores/questions';
-    import { lastResult, attemptCount, correctTotal, type AnswerRecord } from '$lib/stores/results';
+    import { examQuestions } from '$lib/stores/exam';
+    import { lastResult, attemptCount, correctTotal, type AnswerRecord, addResultToHistory } from '$lib/stores/results';
 
   let answers: Record<number, string> = {};
 
   function submit() {
       const records: AnswerRecord[] = [];
       let correct = 0;
-      $questions.forEach((q) => {
+      $examQuestions.forEach((q) => {
         const ans = answers[q.id];
         const ok = ans === q.answer;
         if (ok) correct += 1;
         records.push({ question: q, answer: ans, correct: ok });
       });
       lastResult.set({ records, elapsed: 0 });
-      attemptCount.update((n) => n + $questions.length);
+      addResultToHistory({ records, elapsed: 0 });
+      attemptCount.update((n) => n + $examQuestions.length);
       correctTotal.update((n) => n + correct);
       goto('/exam-result');
     }
   </script>
 
   <h1>Mock Exam</h1>
-  {#if $questions.length === 0}
-  <p>No questions available. <a href="/import-exam">Import a file</a>.</p>
+  {#if $examQuestions.length === 0}
+  <p>No questions available. <a href="/import-questionbank">Import a file</a>.</p>
   {:else}
   <form on:submit|preventDefault={submit}>
-  {#each $questions as q (q.id)}
+  {#each $examQuestions as q (q.id)}
   <div class="question">
     <p>{q.question}</p>
     {#if q.options}

--- a/src/routes/question-bank/+page.svelte
+++ b/src/routes/question-bank/+page.svelte
@@ -86,7 +86,7 @@
 
 <h1>Question Bank</h1>
 {#if $questions.length === 0}
-  <p>No questions loaded. <a href="/import-exam">Import a file</a>.</p>
+  <p>No questions loaded. <a href="/import-questionbank">Import a file</a>.</p>
   <button on:click={newQuestion}>New Question</button>
 {:else}
   <div class="filters">

--- a/src/routes/review/[idx]/+page.svelte
+++ b/src/routes/review/[idx]/+page.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-  import { lastResult } from '$lib/stores/results';
+  import { page } from '$app/stores';
+  import { derived } from 'svelte/store';
+  import { history, type HistoryEntry } from '$lib/stores/results';
+
+  const idx = derived(page, ($p) => parseInt($p.params.idx));
+  const entry = derived([history, idx], ([$history, id]) => $history[id]);
 </script>
 
 <h1>Exam Review</h1>
-{#if $lastResult}
-  {#each $lastResult.records as rec (rec.question.id)}
+{#if $entry}
+  {#each $entry.result.records as rec (rec.question.id)}
     <div class="question">
       <p>{rec.question.question}</p>
       {#if rec.question.options}
@@ -22,7 +27,7 @@
     </div>
   {/each}
 {:else}
-  <p>No results.</p>
+  <p>Exam not found.</p>
 {/if}
 
 <style>

--- a/src/routes/review/[idx]/+page.svelte
+++ b/src/routes/review/[idx]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import { derived } from 'svelte/store';
-  import { history, type HistoryEntry } from '$lib/stores/results';
+  import { history } from '$lib/stores/results';
 
   const idx = derived(page, ($p) => parseInt($p.params.idx));
   const entry = derived([history, idx], ([$history, id]) => $history[id]);
@@ -9,7 +9,7 @@
 
 <h1>Exam Review</h1>
 {#if $entry}
-  {#each $entry.result.records as rec (rec.question.id)}
+  {#each $entry.records as rec (rec.question.id)}
     <div class="question">
       <p>{rec.question.question}</p>
       {#if rec.question.options}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { dataDir } from '$lib/stores/settings';
+  import { questions, saveQuestionBank } from '$lib/stores/questions';
+  import { history, saveHistory } from '$lib/stores/results';
+
+  let dir = '';
+  $: dir = $dataDir;
+
+  function updateDir() {
+    dataDir.set(dir);
+  }
+
+  function exportQuestions() {
+    const data = JSON.stringify($questions, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'question_bank.json';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  }
+
+  function exportHistory() {
+    const data = JSON.stringify($history, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'history.json';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  }
+</script>
+
+<h1>Settings</h1>
+<label>
+  Data Directory <input bind:value={dir} />
+</label>
+<button on:click={updateDir}>Save Path</button>
+<button on:click={exportQuestions}>Export Question Bank</button>
+<button on:click={exportHistory}>Export History</button>
+


### PR DESCRIPTION
## Summary
- track exam history and persist to disk
- load question bank and history on startup
- add History and Settings pages
- support filtering when creating mock exams
- rename Import Exam page to Import Question Bank
- allow configurable data directory for saved files

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68766cdc008c8327827b617198f4bec5