### PR TITLE
Add global image styles and clean up CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ The project uses SvelteKit with adapter-static and Tauri 2. Most of the applicat
 2. **Manage Bank** – The *Question Bank* page lets you edit or delete questions. Remember to click *Save Bank* to persist your changes.
 3. **Add Question** – Use the *Add Question* page to quickly paste text and images when creating new questions.
 4. **Start Exam** – Visit *Mock Exam* to configure the number of questions and start a practice session. After submitting you will see your score.
-5. **Review History** – The *History* page lists past attempts. Click an entry to see detailed answers.
+5. **Review History** – The *History* page lists past attempts. Click an entry to see detailed answers or delete unwanted records.
 6. **Settings** – Change the data directory, export your questions and history, and toggle dark mode.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Qastella is a desktop application for managing question banks and running mock e
 - Run mock exams with randomised questions
 - Review previous exam attempts and track history
 - Export or import question banks in JSON format
+- Attach any number of images to a question and keep them in the JSON export
+- Customisable theme colour and dark mode toggle
 
 ## Development
 
@@ -31,7 +33,8 @@ The project uses SvelteKit with adapter-static and Tauri 2. Most of the applicat
 ## User Guide
 
 1. **Import Questions** – Navigate to *Import Question Bank* and choose a JSON file using the provided example structure. You can also load a built‑in sample.
-2. **Manage Bank** – The *Question Bank* page lets you add, edit or delete questions. Remember to click *Save Bank* to persist your changes.
-3. **Start Exam** – Visit *Mock Exam* to configure the number of questions and start a practice session. After submitting you will see your score.
-4. **Review History** – The *History* page lists past attempts. Click an entry to see detailed answers.
-5. **Settings** – Change the data directory or export your questions and history.
+2. **Manage Bank** – The *Question Bank* page lets you edit or delete questions. Remember to click *Save Bank* to persist your changes.
+3. **Add Question** – Use the *Add Question* page to quickly paste text and images when creating new questions.
+4. **Start Exam** – Visit *Mock Exam* to configure the number of questions and start a practice session. After submitting you will see your score.
+5. **Review History** – The *History* page lists past attempts. Click an entry to see detailed answers.
+6. **Settings** – Change the data directory, export your questions and history, and adjust theme colour or dark mode.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Qastella is a desktop application for managing question banks and running mock e
 - Review previous exam attempts and track history
 - Export or import question banks in JSON format
 - Attach any number of images to a question and keep them in the JSON export
-- Customisable theme colour and dark mode toggle
+- Optional dark mode toggle
 
 ## Development
 
@@ -37,4 +37,4 @@ The project uses SvelteKit with adapter-static and Tauri 2. Most of the applicat
 3. **Add Question** – Use the *Add Question* page to quickly paste text and images when creating new questions.
 4. **Start Exam** – Visit *Mock Exam* to configure the number of questions and start a practice session. After submitting you will see your score.
 5. **Review History** – The *History* page lists past attempts. Click an entry to see detailed answers.
-6. **Settings** – Change the data directory, export your questions and history, and adjust theme colour or dark mode.
+6. **Settings** – Change the data directory, export your questions and history, and toggle dark mode.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ struct RQuestion {
     question: String,
     options: Option<HashMap<String, String>>,
     answer: Value,
+    images: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -49,6 +50,7 @@ fn sample_questions() -> RQuestionBank {
         question: "Example?".into(),
         options: Some(opts),
         answer: Value::String("A".into()),
+        images: None,
     };
 
     let mut src_map = BTreeMap::new();

--- a/src/lib/stores/questions.ts
+++ b/src/lib/stores/questions.ts
@@ -8,6 +8,8 @@ export interface Question {
   question: string;
   options?: Record<string, string>;
   answer: string | string[];
+  /** Optional data URLs representing images for this question */
+  images?: string[];
   source?: string;
   subject?: string;
 }

--- a/src/lib/stores/results.ts
+++ b/src/lib/stores/results.ts
@@ -50,4 +50,16 @@ export function addResultToHistory(res: ExamResult) {
   saveHistory();
 }
 
+/**
+ * Remove a history entry by index and persist the change.
+ */
+export function deleteHistoryItem(index: number) {
+  history.update((list) => {
+    const copy = [...list];
+    copy.splice(index, 1);
+    return copy;
+  });
+  saveHistory();
+}
+
 

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -3,6 +3,29 @@ import { invoke } from '@tauri-apps/api/core';
 
 // Directory used for reading and writing data files
 export const dataDir = writable('');
+// Primary navigation/theme colour
+export const themeColor = writable('#3f51b5');
+// Dark mode toggle
+export const darkMode = writable(false);
+
+// Persist store values to localStorage and update document styles
+themeColor.subscribe((v) => {
+  if (typeof document !== 'undefined') {
+    document.documentElement.style.setProperty('--primary', v);
+  }
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('themeColor', v);
+  }
+});
+
+darkMode.subscribe((v) => {
+  if (typeof document !== 'undefined') {
+    document.documentElement.classList.toggle('dark', v);
+  }
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('darkMode', v ? '1' : '0');
+  }
+});
 
 /**
  * Initialise the data directory setting. The default path is provided by the
@@ -10,11 +33,18 @@ export const dataDir = writable('');
  */
 export async function initSettings() {
   const dir = (await invoke('default_data_dir')) as string;
-  const saved = typeof localStorage !== 'undefined' ? localStorage.getItem('dataDir') : null;
-  dataDir.set(saved || dir);
+  const savedDir = typeof localStorage !== 'undefined' ? localStorage.getItem('dataDir') : null;
+  dataDir.set(savedDir || dir);
   dataDir.subscribe((v) => {
     if (typeof localStorage !== 'undefined') {
       localStorage.setItem('dataDir', v);
     }
   });
+
+  if (typeof localStorage !== 'undefined') {
+    const savedColor = localStorage.getItem('themeColor');
+    const dark = localStorage.getItem('darkMode') === '1';
+    if (savedColor) themeColor.set(savedColor);
+    darkMode.set(dark);
+  }
 }

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -3,21 +3,10 @@ import { invoke } from '@tauri-apps/api/core';
 
 // Directory used for reading and writing data files
 export const dataDir = writable('');
-// Primary navigation/theme colour
-export const themeColor = writable('#3f51b5');
 // Dark mode toggle
 export const darkMode = writable(false);
 
 // Persist store values to localStorage and update document styles
-themeColor.subscribe((v) => {
-  if (typeof document !== 'undefined') {
-    document.documentElement.style.setProperty('--primary', v);
-  }
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem('themeColor', v);
-  }
-});
-
 darkMode.subscribe((v) => {
   if (typeof document !== 'undefined') {
     document.documentElement.classList.toggle('dark', v);
@@ -42,9 +31,7 @@ export async function initSettings() {
   });
 
   if (typeof localStorage !== 'undefined') {
-    const savedColor = localStorage.getItem('themeColor');
     const dark = localStorage.getItem('darkMode') === '1';
-    if (savedColor) themeColor.set(savedColor);
     darkMode.set(dark);
   }
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,7 +6,6 @@ import { loadHistory, saveHistory } from '$lib/stores/results';
 
 let navButtons: HTMLDivElement;
 let navBar: HTMLElement;
-let baseHeight = 0;
 let maxWidth = 0;
 let isCompact = false;
 
@@ -16,7 +15,6 @@ function setCompact(newState: boolean) {
   navButtons.classList.toggle('compact', isCompact);
   navBar.classList.toggle('compact', isCompact);
   if (!isCompact) {
-    baseHeight = navButtons.clientHeight;
     maxWidth = Math.max(maxWidth, navBar.clientWidth);
   }
 }
@@ -24,21 +22,19 @@ function setCompact(newState: boolean) {
 function adjustNav() {
   if (!navButtons || !navBar) return;
   const width = navBar.clientWidth;
-  if (!baseHeight) {
-    baseHeight = navButtons.clientHeight;
-    maxWidth = width;
-  }
+  const first = navButtons.firstElementChild as HTMLElement;
+  const last = navButtons.lastElementChild as HTMLElement;
+  const wrapped = last && first ? last.offsetTop > first.offsetTop : false;
 
   if (!isCompact) {
     maxWidth = Math.max(maxWidth, width);
-    const wrapped = navButtons.scrollHeight > baseHeight + 1;
     if (wrapped || width < maxWidth * 0.5) {
       setCompact(true);
     }
   } else {
-    // add a little hysteresis so it doesn't flicker when resizing around the threshold
-    if (width > maxWidth * 0.55 && navButtons.scrollHeight <= baseHeight + 1) {
+    if (width > maxWidth * 0.55 && !wrapped) {
       setCompact(false);
+      maxWidth = width;
     }
   }
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,23 +33,23 @@
 
 <nav class="main-nav">
   <a class="brand" href="/">Qastella</a>
-  <div class="button-container">
-    <button class="button" aria-label="Home" on:click={() => goto('/') }>
+  <div class="links">
+    <button class="nav-btn" aria-label="Home" on:click={() => goto('/') }>
       <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 1024 1024" fill="currentColor" class="icon">
         <path d="M946.5 505L560.1 118.8l-25.9-25.9a31.5 31.5 0 0 0-44.4 0L77.5 505a63.9 63.9 0 0 0-18.8 46c.4 35.2 29.7 63.3 64.9 63.3h42.5V940h691.8V614.3h43.4c17.1 0 33.2-6.7 45.3-18.8a63.6 63.6 0 0 0 18.7-45.3c0-17-6.7-33.1-18.8-45.2zM568 868H456V664h112v204zm217.9-325.7V868H632V640c0-22.1-17.9-40-40-40H432c-22.1 0-40 17.9-40 40v228H238.1V542.3h-96l370-369.7 23.1 23.1L882 542.3h-96.1z"></path>
       </svg>
     </button>
-    <button class="button" aria-label="Bank" on:click={() => goto('/question-bank') }>
+    <button class="nav-btn" aria-label="Bank" on:click={() => goto('/question-bank') }>
       <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" stroke-width="2" fill="none" stroke="currentColor" class="icon">
         <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" stroke-linejoin="round" stroke-linecap="round"></path>
       </svg>
     </button>
-    <button class="button" aria-label="History" on:click={() => goto('/history') }>
+    <button class="nav-btn" aria-label="History" on:click={() => goto('/history') }>
       <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" class="icon">
         <path d="M12 2.5a5.5 5.5 0 0 1 3.096 10.047 9.005 9.005 0 0 1 5.9 8.181.75.75 0 1 1-1.499.044 7.5 7.5 0 0 0-14.993 0 .75.75 0 0 1-1.5-.045 9.005 9.005 0 0 1 5.9-8.18A5.5 5.5 0 0 1 12 2.5ZM8 8a4 4 0 1 0 8 0 4 4 0 0 0-8 0Z"></path>
       </svg>
     </button>
-    <button class="button" aria-label="Settings" on:click={() => goto('/settings') }>
+    <button class="nav-btn" aria-label="Settings" on:click={() => goto('/settings') }>
       <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" stroke-linejoin="round" stroke-linecap="round" viewBox="0 0 24 24" stroke-width="2" fill="none" stroke="currentColor" class="icon">
         <circle r="1" cy="21" cx="9"></circle>
         <circle r="1" cy="21" cx="20"></circle>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,16 +5,16 @@ import { loadQuestionBank, saveQuestionBank } from '$lib/stores/questions';
 import { loadHistory, saveHistory } from '$lib/stores/results';
 
 let navButtons: HTMLDivElement;
+let navBar: HTMLElement;
+let maxWidth = 0;
 
 function adjustNav() {
   if (!navButtons) return;
+  if (maxWidth === 0) maxWidth = navButtons.scrollWidth;
   const multiLine = navButtons.clientHeight > 40;
-  const halfWindow = window.innerWidth * 0.5;
-  if (multiLine || navButtons.clientWidth < halfWindow || window.innerWidth < 1200) {
-    navButtons.classList.add('compact');
-  } else {
-    navButtons.classList.remove('compact');
-  }
+  const compact = multiLine || navButtons.clientWidth < maxWidth * 0.5;
+  navButtons.classList.toggle('compact', compact);
+  navBar?.classList.toggle('compact', compact);
 }
 
   // Initial load of persistent data and save handlers
@@ -46,7 +46,7 @@ function adjustNav() {
   });
 </script>
 
-<nav class="main-nav">
+<nav class="main-nav" bind:this={navBar}>
   <a class="brand nav-btn" href="/">Qastella</a>
   <div class="nav-buttons" bind:this={navButtons}>
     <a class="nav-btn" href="/exam-config">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -35,6 +35,7 @@
   <a href="/exam-config">Mock Exam</a>
   <a href="/import-questionbank">Import Question Bank</a>
   <a href="/question-bank">Question Bank</a>
+  <a href="/add-question">Add Question</a>
   <a href="/history">History</a>
   <a href="/settings">Settings</a>
 </nav>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -44,4 +44,40 @@
 
 <slot />
 
+<nav class="bottom-nav">
+  <a href="/exam-config" aria-label="Mock Exam">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <path d="m9 12 2 2 4-4" />
+    </svg>
+  </a>
+  <a href="/import-questionbank" aria-label="Import Bank">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M12 5v14m-7-7 7 7 7-7" />
+    </svg>
+  </a>
+  <a href="/question-bank" aria-label="Question Bank">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M4 5h6v14H6a2 2 0 0 1-2-2V5Zm16 0h-6v14h4a2 2 0 0 0 2-2V5Z" />
+    </svg>
+  </a>
+  <a href="/history" aria-label="History">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 3" />
+    </svg>
+  </a>
+  <a href="/add-question" aria-label="Add Question">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M12 5v14M5 12h14" />
+    </svg>
+  </a>
+  <a href="/settings" aria-label="Settings">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1 1 0 0 0 .24 1.09l-.71.71a1 1 0 0 0-.24 1.09l.54 1.87a2 2 0 0 1-1.9 2.53h-1.5a1 1 0 0 0-.95.68l-.39 1.2a2 2 0 0 1-3.8 0l-.39-1.2a1 1 0 0 0-.95-.68H8.67a2 2 0 0 1-1.9-2.53l.54-1.87a1 1 0 0 0-.24-1.09l-.71-.71a1 1 0 0 0 0-1.41l.71-.71a1 1 0 0 0 .24-1.09l-.54-1.87a2 2 0 0 1 1.9-2.53h1.5a1 1 0 0 0 .95-.68l.39-1.2a2 2 0 0 1 3.8 0l.39 1.2a1 1 0 0 0 .95.68h1.5a2 2 0 0 1 1.9 2.53l-.54 1.87a1 1 0 0 0 .24 1.09l.71.71a1 1 0 0 0 0 1.41Z" />
+    </svg>
+  </a>
+</nav>
+
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,8 +1,21 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { initSettings } from '$lib/stores/settings';
-  import { loadQuestionBank, saveQuestionBank } from '$lib/stores/questions';
-  import { loadHistory, saveHistory } from '$lib/stores/results';
+import { loadQuestionBank, saveQuestionBank } from '$lib/stores/questions';
+import { loadHistory, saveHistory } from '$lib/stores/results';
+
+let navButtons: HTMLDivElement;
+
+function adjustNav() {
+  if (!navButtons) return;
+  const multiLine = navButtons.clientHeight > 40;
+  const halfWindow = window.innerWidth * 0.5;
+  if (multiLine || navButtons.clientWidth < halfWindow || window.innerWidth < 1200) {
+    navButtons.classList.add('compact');
+  } else {
+    navButtons.classList.remove('compact');
+  }
+}
 
   // Initial load of persistent data and save handlers
   onMount(() => {
@@ -23,16 +36,19 @@
       saveHistory();
     };
     window.addEventListener('beforeunload', unloadHandler);
+    window.addEventListener('resize', adjustNav);
+    adjustNav();
 
     return () => {
       window.removeEventListener('beforeunload', unloadHandler);
+      window.removeEventListener('resize', adjustNav);
     };
   });
 </script>
 
 <nav class="main-nav">
   <a class="brand nav-btn" href="/">Qastella</a>
-  <div class="nav-buttons">
+  <div class="nav-buttons" bind:this={navButtons}>
     <a class="nav-btn" href="/exam-config">
       <svg viewBox="0 0 24 24" class="icon" aria-hidden="true">
         <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"/>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,13 +10,12 @@ let maxWidth = 0;
 
 function adjustNav() {
   if (!navButtons || !navBar) return;
+  const width = navBar.clientWidth;
   const multiLine = navButtons.clientHeight > 40;
-  const compact = multiLine || navBar.clientWidth < maxWidth * 0.5;
+  const compact =
+    multiLine || (width <= 1000 && width <= window.innerWidth * 0.5);
   navButtons.classList.toggle('compact', compact);
   navBar.classList.toggle('compact', compact);
-  if (!compact) {
-    maxWidth = Math.max(maxWidth, navBar.clientWidth);
-  }
 }
 
   // Initial load of persistent data and save handlers

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,12 +9,14 @@ let navBar: HTMLElement;
 let maxWidth = 0;
 
 function adjustNav() {
-  if (!navButtons) return;
-  if (maxWidth === 0) maxWidth = navButtons.scrollWidth;
+  if (!navButtons || !navBar) return;
   const multiLine = navButtons.clientHeight > 40;
-  const compact = multiLine || navButtons.clientWidth < maxWidth * 0.5;
+  const compact = multiLine || navBar.clientWidth < maxWidth * 0.5;
   navButtons.classList.toggle('compact', compact);
-  navBar?.classList.toggle('compact', compact);
+  navBar.classList.toggle('compact', compact);
+  if (!compact) {
+    maxWidth = Math.max(maxWidth, navBar.clientWidth);
+  }
 }
 
   // Initial load of persistent data and save handlers

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
   import { initSettings } from '$lib/stores/settings';
   import { loadQuestionBank, saveQuestionBank } from '$lib/stores/questions';
   import { loadHistory, saveHistory } from '$lib/stores/results';
@@ -32,13 +33,29 @@
 
 <nav class="main-nav">
   <a class="brand" href="/">Qastella</a>
-  <div class="links">
-    <a href="/exam-config">Mock Exam</a>
-    <a href="/import-questionbank">Import Question Bank</a>
-    <a href="/question-bank">Question Bank</a>
-    <a href="/add-question">Add Question</a>
-    <a href="/history">History</a>
-    <a href="/settings">Settings</a>
+  <div class="button-container">
+    <button class="button" aria-label="Home" on:click={() => goto('/') }>
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 1024 1024" fill="currentColor" class="icon">
+        <path d="M946.5 505L560.1 118.8l-25.9-25.9a31.5 31.5 0 0 0-44.4 0L77.5 505a63.9 63.9 0 0 0-18.8 46c.4 35.2 29.7 63.3 64.9 63.3h42.5V940h691.8V614.3h43.4c17.1 0 33.2-6.7 45.3-18.8a63.6 63.6 0 0 0 18.7-45.3c0-17-6.7-33.1-18.8-45.2zM568 868H456V664h112v204zm217.9-325.7V868H632V640c0-22.1-17.9-40-40-40H432c-22.1 0-40 17.9-40 40v228H238.1V542.3h-96l370-369.7 23.1 23.1L882 542.3h-96.1z"></path>
+      </svg>
+    </button>
+    <button class="button" aria-label="Bank" on:click={() => goto('/question-bank') }>
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" stroke-width="2" fill="none" stroke="currentColor" class="icon">
+        <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" stroke-linejoin="round" stroke-linecap="round"></path>
+      </svg>
+    </button>
+    <button class="button" aria-label="History" on:click={() => goto('/history') }>
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" class="icon">
+        <path d="M12 2.5a5.5 5.5 0 0 1 3.096 10.047 9.005 9.005 0 0 1 5.9 8.181.75.75 0 1 1-1.499.044 7.5 7.5 0 0 0-14.993 0 .75.75 0 0 1-1.5-.045 9.005 9.005 0 0 1 5.9-8.18A5.5 5.5 0 0 1 12 2.5ZM8 8a4 4 0 1 0 8 0 4 4 0 0 0-8 0Z"></path>
+      </svg>
+    </button>
+    <button class="button" aria-label="Settings" on:click={() => goto('/settings') }>
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" stroke-linejoin="round" stroke-linecap="round" viewBox="0 0 24 24" stroke-width="2" fill="none" stroke="currentColor" class="icon">
+        <circle r="1" cy="21" cx="9"></circle>
+        <circle r="1" cy="21" cx="20"></circle>
+        <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"></path>
+      </svg>
+    </button>
   </div>
 </nav>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,12 +33,43 @@
 <nav class="main-nav">
   <a class="brand nav-btn" href="/">Qastella</a>
   <div class="nav-buttons">
-    <a class="nav-btn" href="/exam-config">Mock Exam</a>
-    <a class="nav-btn" href="/import-questionbank">Import Question Bank</a>
-    <a class="nav-btn" href="/question-bank">Question Bank</a>
-    <a class="nav-btn" href="/history">History</a>
-    <a class="nav-btn" href="/add-question">Add Question</a>
-    <a class="nav-btn" href="/settings">Settings</a>
+    <a class="nav-btn" href="/exam-config">
+      <svg viewBox="0 0 24 24" class="icon" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z"/>
+      </svg>
+      <span class="label">Mock Exam</span>
+    </a>
+    <a class="nav-btn" href="/import-questionbank">
+      <svg viewBox="0 0 24 24" class="icon" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"/>
+      </svg>
+      <span class="label">Import</span>
+    </a>
+    <a class="nav-btn" href="/question-bank">
+      <svg viewBox="0 0 24 24" class="icon" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z"/>
+      </svg>
+      <span class="label">Question Bank</span>
+    </a>
+    <a class="nav-btn" href="/history">
+      <svg viewBox="0 0 24 24" class="icon" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      </svg>
+      <span class="label">History</span>
+    </a>
+    <a class="nav-btn" href="/add-question">
+      <svg viewBox="0 0 24 24" class="icon" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v6m3-3H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      </svg>
+      <span class="label">Add Question</span>
+    </a>
+    <a class="nav-btn" href="/settings">
+      <svg viewBox="0 0 24 24" class="icon" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z"/>
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+      </svg>
+      <span class="label">Settings</span>
+    </a>
   </div>
 </nav>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,7 @@ import { loadHistory, saveHistory } from '$lib/stores/results';
 let navButtons: HTMLDivElement;
 let navBar: HTMLElement;
 let maxWidth = 0;
+let rowHeight = 0;
 let isCompact = false;
 
 function setCompact(newState: boolean) {
@@ -22,9 +23,10 @@ function setCompact(newState: boolean) {
 function adjustNav() {
   if (!navButtons || !navBar) return;
   const width = navBar.clientWidth;
-  const first = navButtons.firstElementChild as HTMLElement;
-  const last = navButtons.lastElementChild as HTMLElement;
-  const wrapped = last && first ? last.offsetTop > first.offsetTop : false;
+  if (!rowHeight) {
+    rowHeight = navButtons.clientHeight;
+  }
+  const wrapped = navButtons.scrollHeight > rowHeight + 1;
 
   if (!isCompact) {
     maxWidth = Math.max(maxWidth, width);
@@ -32,7 +34,7 @@ function adjustNav() {
       setCompact(true);
     }
   } else {
-    if (width > maxWidth * 0.55 && !wrapped) {
+    if (width > maxWidth * 0.6 && !wrapped) {
       setCompact(false);
       maxWidth = width;
     }
@@ -59,7 +61,11 @@ function adjustNav() {
     };
     window.addEventListener('beforeunload', unloadHandler);
     window.addEventListener('resize', adjustNav);
-    adjustNav();
+    // capture base row height once layout is rendered
+    requestAnimationFrame(() => {
+      rowHeight = navButtons.clientHeight;
+      adjustNav();
+    });
 
     return () => {
       window.removeEventListener('beforeunload', unloadHandler);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,16 +7,40 @@ import { loadHistory, saveHistory } from '$lib/stores/results';
 let navButtons: HTMLDivElement;
 let navBar: HTMLElement;
 let baseHeight = 0;
+let maxWidth = 0;
+let isCompact = false;
+
+function setCompact(newState: boolean) {
+  if (isCompact === newState) return;
+  isCompact = newState;
+  navButtons.classList.toggle('compact', isCompact);
+  navBar.classList.toggle('compact', isCompact);
+  if (!isCompact) {
+    baseHeight = navButtons.clientHeight;
+    maxWidth = Math.max(maxWidth, navBar.clientWidth);
+  }
+}
 
 function adjustNav() {
   if (!navButtons || !navBar) return;
   const width = navBar.clientWidth;
-  if (!baseHeight) baseHeight = navButtons.clientHeight;
-  const multiLine = navButtons.scrollHeight > baseHeight + 1;
-  const compact =
-    multiLine || (width <= 1000 && width <= window.innerWidth * 0.5);
-  navButtons.classList.toggle('compact', compact);
-  navBar.classList.toggle('compact', compact);
+  if (!baseHeight) {
+    baseHeight = navButtons.clientHeight;
+    maxWidth = width;
+  }
+
+  if (!isCompact) {
+    maxWidth = Math.max(maxWidth, width);
+    const wrapped = navButtons.scrollHeight > baseHeight + 1;
+    if (wrapped || width < maxWidth * 0.5) {
+      setCompact(true);
+    }
+  } else {
+    // add a little hysteresis so it doesn't flicker when resizing around the threshold
+    if (width > maxWidth * 0.55 && navButtons.scrollHeight <= baseHeight + 1) {
+      setCompact(false);
+    }
+  }
 }
 
   // Initial load of persistent data and save handlers

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -32,52 +32,17 @@
 
 <nav class="main-nav">
   <a class="brand" href="/">Qastella</a>
-  <div class="links">
-    <a href="/exam-config">Mock Exam</a>
-    <a href="/import-questionbank">Import Question Bank</a>
-    <a href="/question-bank">Question Bank</a>
-    <a href="/history">History</a>
-    <a href="/add-question">Add Question</a>
-    <a href="/settings">Settings</a>
+  <div class="nav-buttons">
+    <a class="nav-btn" href="/exam-config">Mock Exam</a>
+    <a class="nav-btn" href="/import-questionbank">Import Question Bank</a>
+    <a class="nav-btn" href="/question-bank">Question Bank</a>
+    <a class="nav-btn" href="/history">History</a>
+    <a class="nav-btn" href="/add-question">Add Question</a>
+    <a class="nav-btn" href="/settings">Settings</a>
   </div>
 </nav>
 
-<slot />
 
-<nav class="bottom-nav">
-  <a href="/exam-config" aria-label="Mock Exam">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <path d="m9 12 2 2 4-4" />
-    </svg>
-  </a>
-  <a href="/import-questionbank" aria-label="Import Bank">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M12 5v14m-7-7 7 7 7-7" />
-    </svg>
-  </a>
-  <a href="/question-bank" aria-label="Question Bank">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M4 5h6v14H6a2 2 0 0 1-2-2V5Zm16 0h-6v14h4a2 2 0 0 0 2-2V5Z" />
-    </svg>
-  </a>
-  <a href="/history" aria-label="History">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <circle cx="12" cy="12" r="9" />
-      <path d="M12 7v5l3 3" />
-    </svg>
-  </a>
-  <a href="/add-question" aria-label="Add Question">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <path d="M12 5v14M5 12h14" />
-    </svg>
-  </a>
-  <a href="/settings" aria-label="Settings">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-      <circle cx="12" cy="12" r="3" />
-      <path d="M19.4 15a1 1 0 0 0 .24 1.09l-.71.71a1 1 0 0 0-.24 1.09l.54 1.87a2 2 0 0 1-1.9 2.53h-1.5a1 1 0 0 0-.95.68l-.39 1.2a2 2 0 0 1-3.8 0l-.39-1.2a1 1 0 0 0-.95-.68H8.67a2 2 0 0 1-1.9-2.53l.54-1.87a1 1 0 0 0-.24-1.09l-.71-.71a1 1 0 0 0 0-1.41l.71-.71a1 1 0 0 0 .24-1.09l-.54-1.87a2 2 0 0 1 1.9-2.53h1.5a1 1 0 0 0 .95-.68l.39-1.2a2 2 0 0 1 3.8 0l.39 1.2a1 1 0 0 0 .95.68h1.5a2 2 0 0 1 1.9 2.53l-.54 1.87a1 1 0 0 0 .24 1.09l.71.71a1 1 0 0 0 0 1.41Z" />
-    </svg>
-  </a>
-</nav>
+<slot />
 
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
   import { initSettings } from '$lib/stores/settings';
   import { loadQuestionBank, saveQuestionBank } from '$lib/stores/questions';
   import { loadHistory, saveHistory } from '$lib/stores/results';
@@ -34,28 +33,12 @@
 <nav class="main-nav">
   <a class="brand" href="/">Qastella</a>
   <div class="links">
-    <button class="nav-btn" aria-label="Home" on:click={() => goto('/') }>
-      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 1024 1024" fill="currentColor" class="icon">
-        <path d="M946.5 505L560.1 118.8l-25.9-25.9a31.5 31.5 0 0 0-44.4 0L77.5 505a63.9 63.9 0 0 0-18.8 46c.4 35.2 29.7 63.3 64.9 63.3h42.5V940h691.8V614.3h43.4c17.1 0 33.2-6.7 45.3-18.8a63.6 63.6 0 0 0 18.7-45.3c0-17-6.7-33.1-18.8-45.2zM568 868H456V664h112v204zm217.9-325.7V868H632V640c0-22.1-17.9-40-40-40H432c-22.1 0-40 17.9-40 40v228H238.1V542.3h-96l370-369.7 23.1 23.1L882 542.3h-96.1z"></path>
-      </svg>
-    </button>
-    <button class="nav-btn" aria-label="Bank" on:click={() => goto('/question-bank') }>
-      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" stroke-width="2" fill="none" stroke="currentColor" class="icon">
-        <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" stroke-linejoin="round" stroke-linecap="round"></path>
-      </svg>
-    </button>
-    <button class="nav-btn" aria-label="History" on:click={() => goto('/history') }>
-      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="currentColor" class="icon">
-        <path d="M12 2.5a5.5 5.5 0 0 1 3.096 10.047 9.005 9.005 0 0 1 5.9 8.181.75.75 0 1 1-1.499.044 7.5 7.5 0 0 0-14.993 0 .75.75 0 0 1-1.5-.045 9.005 9.005 0 0 1 5.9-8.18A5.5 5.5 0 0 1 12 2.5ZM8 8a4 4 0 1 0 8 0 4 4 0 0 0-8 0Z"></path>
-      </svg>
-    </button>
-    <button class="nav-btn" aria-label="Settings" on:click={() => goto('/settings') }>
-      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" stroke-linejoin="round" stroke-linecap="round" viewBox="0 0 24 24" stroke-width="2" fill="none" stroke="currentColor" class="icon">
-        <circle r="1" cy="21" cx="9"></circle>
-        <circle r="1" cy="21" cx="20"></circle>
-        <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"></path>
-      </svg>
-    </button>
+    <a href="/exam-config">Mock Exam</a>
+    <a href="/import-questionbank">Import Question Bank</a>
+    <a href="/question-bank">Question Bank</a>
+    <a href="/history">History</a>
+    <a href="/add-question">Add Question</a>
+    <a href="/settings">Settings</a>
   </div>
 </nav>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,12 +6,13 @@ import { loadHistory, saveHistory } from '$lib/stores/results';
 
 let navButtons: HTMLDivElement;
 let navBar: HTMLElement;
-let maxWidth = 0;
+let baseHeight = 0;
 
 function adjustNav() {
   if (!navButtons || !navBar) return;
   const width = navBar.clientWidth;
-  const multiLine = navButtons.clientHeight > 40;
+  if (!baseHeight) baseHeight = navButtons.clientHeight;
+  const multiLine = navButtons.scrollHeight > baseHeight + 1;
   const compact =
     multiLine || (width <= 1000 && width <= window.innerWidth * 0.5);
   navButtons.classList.toggle('compact', compact);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -31,7 +31,7 @@
 </script>
 
 <nav class="main-nav">
-  <a class="brand" href="/">Qastella</a>
+  <a class="brand nav-btn" href="/">Qastella</a>
   <div class="nav-buttons">
     <a class="nav-btn" href="/exam-config">Mock Exam</a>
     <a class="nav-btn" href="/import-questionbank">Import Question Bank</a>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -31,13 +31,15 @@
 </script>
 
 <nav class="main-nav">
-  <a href="/">Dashboard</a>
-  <a href="/exam-config">Mock Exam</a>
-  <a href="/import-questionbank">Import Question Bank</a>
-  <a href="/question-bank">Question Bank</a>
-  <a href="/add-question">Add Question</a>
-  <a href="/history">History</a>
-  <a href="/settings">Settings</a>
+  <a class="brand" href="/">Qastella</a>
+  <div class="links">
+    <a href="/exam-config">Mock Exam</a>
+    <a href="/import-questionbank">Import Question Bank</a>
+    <a href="/question-bank">Question Bank</a>
+    <a href="/add-question">Add Question</a>
+    <a href="/history">History</a>
+    <a href="/settings">Settings</a>
+  </div>
 </nav>
 
 <slot />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,7 +7,6 @@ import { loadHistory, saveHistory } from '$lib/stores/results';
 let navButtons: HTMLDivElement;
 let navBar: HTMLElement;
 let maxWidth = 0;
-let rowHeight = 0;
 let isCompact = false;
 
 function setCompact(newState: boolean) {
@@ -23,21 +22,14 @@ function setCompact(newState: boolean) {
 function adjustNav() {
   if (!navButtons || !navBar) return;
   const width = navBar.clientWidth;
-  if (!rowHeight) {
-    rowHeight = navButtons.clientHeight;
+  if (maxWidth === 0 || (!isCompact && width > maxWidth)) {
+    maxWidth = width;
   }
-  const wrapped = navButtons.scrollHeight > rowHeight + 1;
-
-  if (!isCompact) {
-    maxWidth = Math.max(maxWidth, width);
-    if (wrapped || width < maxWidth * 0.5) {
-      setCompact(true);
-    }
-  } else {
-    if (width > maxWidth * 0.6 && !wrapped) {
-      setCompact(false);
-      maxWidth = width;
-    }
+  if (!isCompact && width < maxWidth * 0.6) {
+    setCompact(true);
+  } else if (isCompact && width > maxWidth * 0.7) {
+    setCompact(false);
+    maxWidth = width;
   }
 }
 
@@ -61,11 +53,7 @@ function adjustNav() {
     };
     window.addEventListener('beforeunload', unloadHandler);
     window.addEventListener('resize', adjustNav);
-    // capture base row height once layout is rendered
-    requestAnimationFrame(() => {
-      rowHeight = navButtons.clientHeight;
-      adjustNav();
-    });
+    requestAnimationFrame(adjustNav);
 
     return () => {
       window.removeEventListener('beforeunload', unloadHandler);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,11 +31,6 @@
     <a href="/import-questionbank">Import Question Bank</a>
     <a href="/question-bank">Manage Bank</a>
   </nav>
-  <div class="shapes">
-    <div class="triangle"></div>
-    <div class="circle"></div>
-    <div class="square"></div>
-  </div>
 </main>
 
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -31,6 +31,11 @@
     <a href="/import-questionbank">Import Question Bank</a>
     <a href="/question-bank">Manage Bank</a>
   </nav>
+  <div class="shapes">
+    <div class="triangle"></div>
+    <div class="circle"></div>
+    <div class="square"></div>
+  </div>
 </main>
 
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,12 +8,12 @@
   );
 </script>
 
-<main class="container">
+<main class="container dashboard">
   <h1>Qastella Dashboard</h1>
   <section class="stats">
-    <p>Total Questions: {$questions.length}</p>
-    <p>Attempts: {$attemptCount}</p>
-    <p>Accuracy: {$accuracy}%</p>
+    <div>Total Questions: {$questions.length}</div>
+    <div>Attempts: {$attemptCount}</div>
+    <div>Accuracy: {$accuracy}%</div>
   </section>
   {#if $lastResult}
     <section class="recent">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,13 +23,13 @@
         {$lastResult.records.filter((r) => r.correct).length} /
         {$lastResult.records.length}
       </p>
-      <a href="/exam-result">View details</a>
+      <a class="nav-btn" href="/exam-result">View details</a>
     </section>
   {/if}
   <nav class="quick">
-    <a href="/exam-config">Start Mock Exam</a>
-    <a href="/import-questionbank">Import Question Bank</a>
-    <a href="/question-bank">Manage Bank</a>
+    <a class="nav-btn" href="/exam-config">Start Mock Exam</a>
+    <a class="nav-btn" href="/import-questionbank">Import Question Bank</a>
+    <a class="nav-btn" href="/question-bank">Manage Bank</a>
   </nav>
 </main>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { derived } from 'svelte/store';
   import { questions } from '$lib/stores/questions';
   import { lastResult, attemptCount, correctTotal } from '$lib/stores/results';
+  import { goto } from '$app/navigation';
 
   const accuracy = derived([correctTotal, attemptCount], ([$c, $a]) =>
     $a === 0 ? 0 : Math.round(($c / $a) * 100)
@@ -27,9 +28,9 @@
     </section>
   {/if}
   <nav class="quick">
-    <a class="nav-btn" href="/exam-config">Start Mock Exam</a>
-    <a class="nav-btn" href="/import-questionbank">Import Question Bank</a>
-    <a class="nav-btn" href="/question-bank">Manage Bank</a>
+    <button class="nav-btn" type="button" on:click={() => goto('/exam-config')}>Start Mock Exam</button>
+    <button class="nav-btn" type="button" on:click={() => goto('/import-questionbank')}>Import Question Bank</button>
+    <button class="nav-btn" type="button" on:click={() => goto('/question-bank')}>Manage Bank</button>
   </nav>
 </main>
 

--- a/src/routes/add-question/+page.svelte
+++ b/src/routes/add-question/+page.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import { questions, type Question } from '$lib/stores/questions';
+  import { goto } from '$app/navigation';
+  import { get } from 'svelte/store';
+  import { fade } from 'svelte/transition';
+
+  let questionText = '';
+  let answerValue = '';
+  let options: Record<string, string> = { A: '', B: '' };
+  let images: string[] = [];
+  let source = '';
+  let subject = '';
+
+  function addOption() {
+    const letters = Object.keys(options);
+    const next = letters.length
+      ? String.fromCharCode(Math.max(...letters.map(l => l.charCodeAt(0))) + 1)
+      : 'A';
+    options = { ...options, [next]: '' };
+  }
+
+  function removeOption(key: string) {
+    const { [key]: _removed, ...rest } = options;
+    options = rest;
+  }
+
+  function handleFiles(files: FileList | null) {
+    if (!files) return;
+    Array.from(files).forEach((f) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        images = [...images, reader.result as string];
+      };
+      reader.readAsDataURL(f);
+    });
+  }
+
+  function handlePaste(e: ClipboardEvent) {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    for (const it of items) {
+      if (it.type.startsWith('image/')) {
+        const f = it.getAsFile();
+        if (f) handleFiles({ 0: f, length: 1, item: () => f } as unknown as FileList);
+      }
+    }
+  }
+
+  function onFileChange(event: Event) {
+    const input = event.target as HTMLInputElement;
+    handleFiles(input.files);
+    input.value = '';
+  }
+
+  function removeImage(i: number) {
+    images = images.filter((_, idx) => idx !== i);
+  }
+
+  function save() {
+    const list = get(questions);
+    const id = Math.max(0, ...list.map(q => q.id)) + 1;
+    const q: Question = {
+      id,
+      type: 'single',
+      question: questionText,
+      options,
+      answer: answerValue,
+      images,
+      source,
+      subject
+    };
+    questions.set([...list, q]);
+    goto('/question-bank');
+  }
+</script>
+
+<main on:paste={handlePaste}>
+  <h1>Add Question</h1>
+  <form on:submit|preventDefault={save}>
+    <label>
+      Question
+      <textarea rows="5" bind:value={questionText}></textarea>
+    </label>
+
+    {#if Object.keys(options).length}
+      {#each Object.entries(options) as [key, val]}
+        <label>
+          {key}: <input bind:value={options[key]} />
+          <button type="button" on:click={() => removeOption(key)}>x</button>
+        </label>
+      {/each}
+    {/if}
+    <button type="button" on:click={addOption}>Add Option</button>
+
+    {#if images.length}
+      <div class="images thumbs">
+        {#each images as img, i (i)}
+          <div class="img-wrapper" transition:fade>
+            <img src={img} alt="question image {i}" />
+            <button type="button" on:click={() => removeImage(i)}>x</button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+    <label>
+      Add Images
+      <input type="file" accept="image/*" multiple on:change={onFileChange} />
+    </label>
+
+    <label>
+      Answer
+      <input bind:value={answerValue} />
+    </label>
+    <label>Source <input bind:value={source} /></label>
+    <label>Subject <input bind:value={subject} /></label>
+    <button type="submit">Save</button>
+    <button type="button" on:click={() => goto('/question-bank')}>Cancel</button>
+  </form>
+</main>
+
+<style>
+  textarea {
+    width: 100%;
+    margin-bottom: 0.5rem;
+  }
+</style>

--- a/src/routes/add-question/+page.svelte
+++ b/src/routes/add-question/+page.svelte
@@ -11,6 +11,15 @@
   let source = '';
   let subject = '';
 
+  function clearForm() {
+    questionText = '';
+    answerValue = '';
+    options = { A: '', B: '' };
+    images = [];
+    source = '';
+    subject = '';
+  }
+
   function addOption() {
     const letters = Object.keys(options);
     const next = letters.length
@@ -56,7 +65,7 @@
     images = images.filter((_, idx) => idx !== i);
   }
 
-  function save() {
+  function save(ev?: Event, redirect = true) {
     const list = get(questions);
     const id = Math.max(0, ...list.map(q => q.id)) + 1;
     const q: Question = {
@@ -70,7 +79,11 @@
       subject
     };
     questions.set([...list, q]);
-    goto('/question-bank');
+    if (redirect) {
+      goto('/question-bank');
+    } else {
+      clearForm();
+    }
   }
 </script>
 
@@ -114,6 +127,7 @@
     <label>Source <input bind:value={source} /></label>
     <label>Subject <input bind:value={subject} /></label>
     <button type="submit">Save</button>
+    <button type="button" on:click={() => save(undefined, false)}>Save & Add Another</button>
     <button type="button" on:click={() => goto('/question-bank')}>Cancel</button>
   </form>
 </main>

--- a/src/routes/add-question/+page.svelte
+++ b/src/routes/add-question/+page.svelte
@@ -10,6 +10,7 @@
   let images: string[] = [];
   let source = '';
   let subject = '';
+  let lightbox: string | null = null;
 
   function clearForm() {
     questionText = '';
@@ -109,8 +110,10 @@
       <div class="images thumbs">
         {#each images as img, i (i)}
           <div class="img-wrapper" transition:fade>
-            <img src={img} alt="question image {i}" />
-            <button type="button" on:click={() => removeImage(i)}>x</button>
+            <button type="button" class="thumb" on:click={() => (lightbox = img)}>
+              <img src={img} alt="question image {i}" />
+            </button>
+            <button type="button" class="remove" on:click={() => removeImage(i)}>x</button>
           </div>
         {/each}
       </div>
@@ -130,6 +133,15 @@
     <button type="button" on:click={() => save(undefined, false)}>Save & Add Another</button>
     <button type="button" on:click={() => goto('/question-bank')}>Cancel</button>
   </form>
+  {#if lightbox}
+    <button
+      type="button"
+      class="lightbox"
+      on:click={() => (lightbox = null)}
+    >
+      <img src={lightbox} alt="enlarged" />
+    </button>
+  {/if}
 </main>
 
 <style>

--- a/src/routes/add-question/+page.svelte
+++ b/src/routes/add-question/+page.svelte
@@ -122,16 +122,19 @@
 
     {#if Object.keys(options).length}
       {#each Object.entries(options) as [key, val]}
-        <label>
-          {key}: <input bind:value={options[key]} />
-          <input
-            type={qType === 'single' ? 'radio' : 'checkbox'}
-            name="correct"
-            checked={correct.includes(key)}
-            on:change={() => toggleCorrect(key)}
-          />
+        <div class="option-row">
+          <span>{key}: <input bind:value={options[key]} /></span>
+          <label class="option-check {qType === 'single' ? 'radio' : 'checkbox'}">
+            <input
+              type={qType === 'single' ? 'radio' : 'checkbox'}
+              name="correct"
+              checked={correct.includes(key)}
+              on:change={() => toggleCorrect(key)}
+            />
+            <span class="mark"></span>
+          </label>
           <button type="button" on:click={() => removeOption(key)}>x</button>
-        </label>
+        </div>
       {/each}
     {/if}
     <button type="button" on:click={addOption}>Add Option</button>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { history } from '$lib/stores/results';
+  import { goto } from '$app/navigation';
 </script>
 
 <main>
@@ -22,7 +23,15 @@
             <td>
               {item.records.filter((r) => r.correct).length}/{item.records.length}
             </td>
-            <td><a class="nav-btn" href={`/review/${i}`}>Review</a></td>
+            <td>
+              <button
+                class="nav-btn"
+                type="button"
+                on:click={() => goto(`/review/${i}`)}
+              >
+                Review
+              </button>
+            </td>
           </tr>
         {/each}
       </tbody>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { history } from '$lib/stores/results';
+  import { history, deleteHistoryItem } from '$lib/stores/results';
   import { goto } from '$app/navigation';
 </script>
 
@@ -30,6 +30,12 @@
                 on:click={() => goto(`/review/${i}`)}
               >
                 Review
+              </button>
+              <button
+                type="button"
+                on:click={() => deleteHistoryItem(i)}
+              >
+                Delete
               </button>
             </td>
           </tr>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -7,15 +7,25 @@
   {#if $history.length === 0}
     <p>No exam history.</p>
   {:else}
-    <ul>
-      {#each $history as item, i}
-        <li>
-          <a href={`/review/${i}`}
-            >{new Date(item.timestamp).toLocaleString()} -
-            {item.records.filter((r) => r.correct).length}/{item.records.length}</a
-          >
-        </li>
-      {/each}
-    </ul>
+    <table class="history">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Score</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each $history as item, i}
+          <tr>
+            <td>{new Date(item.timestamp).toLocaleString()}</td>
+            <td>
+              {item.records.filter((r) => r.correct).length}/{item.records.length}
+            </td>
+            <td><a class="nav-btn" href={`/review/${i}`}>Review</a></td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
   {/if}
 </main>

--- a/src/routes/import-questionbank/+page.svelte
+++ b/src/routes/import-questionbank/+page.svelte
@@ -63,9 +63,4 @@
   <a href="/question-bank">View Questions</a>
 </main>
 
-<style>
-pre {
-  background-color: #eee;
-  padding: 1em;
-}
-</style>
+

--- a/src/routes/import-questionbank/+page.svelte
+++ b/src/routes/import-questionbank/+page.svelte
@@ -60,7 +60,6 @@
     ]
   }
 }}`}</pre>
-  <a href="/question-bank">View Questions</a>
 </main>
 
 

--- a/src/routes/mock-exam/+page.svelte
+++ b/src/routes/mock-exam/+page.svelte
@@ -6,6 +6,7 @@
 
   // Stores selected answers keyed by question id
   let answers: Record<number, string> = {};
+  let lightbox: string | null = null;
 
   /**
    * Grade the answers and store the result before moving to the result page.
@@ -41,7 +42,7 @@
           {#if q.images}
             <div class="images">
               {#each q.images as img}
-                <img src={img} alt="" transition:fade />
+                <img src={img} alt="" transition:fade on:click={() => (lightbox = img)} />
               {/each}
             </div>
           {/if}
@@ -62,6 +63,11 @@
       {/each}
       <button type="submit">Submit</button>
     </form>
+  {/if}
+  {#if lightbox}
+    <div class="lightbox" on:click={() => (lightbox = null)} transition:fade>
+      <img src={lightbox} alt="enlarged" />
+    </div>
   {/if}
 </main>
 

--- a/src/routes/mock-exam/+page.svelte
+++ b/src/routes/mock-exam/+page.svelte
@@ -37,7 +37,7 @@
   {:else}
     <form on:submit|preventDefault={submit}>
       {#each $examQuestions as q (q.id)}
-        <div class="question" transition:fade>
+        <div class="question review-card" transition:fade>
           <p>{q.question}</p>
           {#if q.images}
             <div class="images">

--- a/src/routes/mock-exam/+page.svelte
+++ b/src/routes/mock-exam/+page.svelte
@@ -2,6 +2,7 @@
     import { goto } from '$app/navigation';
     import { examQuestions } from '$lib/stores/exam';
     import { lastResult, attemptCount, correctTotal, type AnswerRecord, addResultToHistory } from '$lib/stores/results';
+    import { fade } from 'svelte/transition';
 
   // Stores selected answers keyed by question id
   let answers: Record<number, string> = {};
@@ -35,8 +36,15 @@
   {:else}
     <form on:submit|preventDefault={submit}>
       {#each $examQuestions as q (q.id)}
-        <div class="question">
+        <div class="question" transition:fade>
           <p>{q.question}</p>
+          {#if q.images}
+            <div class="images">
+              {#each q.images as img}
+                <img src={img} alt="" transition:fade />
+              {/each}
+            </div>
+          {/if}
           {#if q.options}
             {#each Object.entries(q.options) as [key, text]}
               <label>
@@ -56,5 +64,7 @@
     </form>
   {/if}
 </main>
+
+
 
 

--- a/src/routes/mock-exam/+page.svelte
+++ b/src/routes/mock-exam/+page.svelte
@@ -42,7 +42,13 @@
           {#if q.images}
             <div class="images">
               {#each q.images as img}
-                <img src={img} alt="" transition:fade on:click={() => (lightbox = img)} />
+                <button
+                  type="button"
+                  class="img-thumb"
+                  on:click={() => (lightbox = img)}
+                >
+                  <img src={img} alt="" transition:fade />
+                </button>
               {/each}
             </div>
           {/if}
@@ -65,9 +71,14 @@
     </form>
   {/if}
   {#if lightbox}
-    <div class="lightbox" on:click={() => (lightbox = null)} transition:fade>
+    <button
+      type="button"
+      class="lightbox"
+      on:click={() => (lightbox = null)}
+      transition:fade
+    >
       <img src={lightbox} alt="enlarged" />
-    </div>
+    </button>
   {/if}
 </main>
 

--- a/src/routes/question-bank/+page.svelte
+++ b/src/routes/question-bank/+page.svelte
@@ -207,16 +207,19 @@
     </label>
     {#if editing.options}
       {#each Object.entries(editing.options) as [key, val]}
-        <label>
-          {key}: <input bind:value={editing.options![key]} />
-          <input
-            type={editing.type === 'single' ? 'radio' : 'checkbox'}
-            name="correctEdit"
-            checked={correct.includes(key)}
-            on:change={() => toggleCorrect(key)}
-          />
+        <div class="option-row">
+          <span>{key}: <input bind:value={editing.options![key]} /></span>
+          <label class="option-check {editing.type === 'single' ? 'radio' : 'checkbox'}">
+            <input
+              type={editing.type === 'single' ? 'radio' : 'checkbox'}
+              name="correctEdit"
+              checked={correct.includes(key)}
+              on:change={() => toggleCorrect(key)}
+            />
+            <span class="mark"></span>
+          </label>
           <button type="button" on:click={() => removeOption(key)}>x</button>
-        </label>
+        </div>
       {/each}
     {/if}
     <button type="button" on:click={addOption}>Add Option</button>

--- a/src/routes/question-bank/+page.svelte
+++ b/src/routes/question-bank/+page.svelte
@@ -24,6 +24,7 @@
   let editing: Question | null = null;
   let answerValue: string = '';
   let dlg: HTMLDialogElement | null = null;
+  let lightbox: string | null = null;
 
   /**
    * Open the edit dialog for an existing question.
@@ -118,7 +119,6 @@
   <h1>Question Bank</h1>
   {#if $questions.length === 0}
     <p>No questions loaded. <a href="/import-questionbank">Import a file</a>.</p>
-    <a href="/add-question">New Question</a>
   {:else}
     <div class="filters">
       <input placeholder="Keyword" bind:value={$keyword} />
@@ -170,7 +170,6 @@
         {/each}
       </tbody>
     </table>
-    <a href="/add-question">New Question</a>
     <button class="save-bank" on:click={saveQuestionBank}>Save Bank</button>
   {/if}
 </main>
@@ -195,8 +194,10 @@
       <div class="images thumbs">
         {#each editing.images as img, i (i)}
           <div class="img-wrapper" transition:fade>
-            <img src={img} alt="question image {i}" />
-            <button type="button" on:click={() => removeImage(i)}>x</button>
+            <button type="button" class="thumb" on:click={() => (lightbox = img)}>
+              <img src={img} alt="question image {i}" />
+            </button>
+            <button type="button" class="remove" on:click={() => removeImage(i)}>x</button>
           </div>
         {/each}
       </div>
@@ -216,5 +217,14 @@
   {/if}
 
 </dialog>
+{#if lightbox}
+  <button
+    type="button"
+    class="lightbox"
+    on:click={() => (lightbox = null)}
+  >
+    <img src={lightbox} alt="enlarged" />
+  </button>
+{/if}
 
 

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -1,13 +1,21 @@
 <script lang="ts">
   import { lastResult } from '$lib/stores/results';
+  import { fade } from 'svelte/transition';
 </script>
 
 <main>
   <h1>Exam Review</h1>
   {#if $lastResult}
     {#each $lastResult.records as rec (rec.question.id)}
-      <div class="question">
+      <div class="question" transition:fade>
         <p>{rec.question.question}</p>
+        {#if rec.question.images}
+          <div class="images">
+            {#each rec.question.images as img}
+              <img src={img} alt="" transition:fade />
+            {/each}
+          </div>
+        {/if}
         {#if rec.question.options}
           <ul>
             {#each Object.entries(rec.question.options) as [key, text]}
@@ -34,5 +42,6 @@
     <p>No results.</p>
   {/if}
 </main>
+
 
 

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -14,7 +14,13 @@
         {#if rec.question.images}
           <div class="images">
             {#each rec.question.images as img}
-              <img src={img} alt="" transition:fade on:click={() => (lightbox = img)} />
+              <button
+                type="button"
+                class="img-thumb"
+                on:click={() => (lightbox = img)}
+              >
+                <img src={img} alt="" transition:fade />
+              </button>
             {/each}
           </div>
         {/if}
@@ -44,9 +50,14 @@
     <p>No results.</p>
   {/if}
   {#if lightbox}
-    <div class="lightbox" on:click={() => (lightbox = null)} transition:fade>
+    <button
+      type="button"
+      class="lightbox"
+      on:click={() => (lightbox = null)}
+      transition:fade
+    >
       <img src={lightbox} alt="enlarged" />
-    </div>
+    </button>
   {/if}
 </main>
 

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -26,21 +26,30 @@
           </div>
         {/if}
         {#if rec.question.options}
-          <ul>
+          <div class="options">
             {#each Object.entries(rec.question.options) as [key, text]}
-              <li
-                class={
-                  rec.question.answer == key
-                    ? 'correct'
-                    : rec.answer == key && !rec.correct
-                    ? 'wrong'
-                    : ''
+              <button
+                type="button"
+                class="option-btn"
+                class:correct={
+                  Array.isArray(rec.question.answer)
+                    ? rec.question.answer.includes(key)
+                    : rec.question.answer === key
                 }
+                class:wrong={
+                  (Array.isArray(rec.answer)
+                    ? rec.answer.includes(key)
+                    : rec.answer === key) &&
+                  !(Array.isArray(rec.question.answer)
+                    ? rec.question.answer.includes(key)
+                    : rec.question.answer === key)
+                }
+                disabled
               >
                 {key}. {text}
-              </li>
+              </button>
             {/each}
-          </ul>
+          </div>
         {:else}
           <p>Correct answer: {rec.question.answer}</p>
           <p>Your answer: {rec.answer}</p>

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { lastResult } from '$lib/stores/results';
   import { fade } from 'svelte/transition';
+
+  let lightbox: string | null = null;
 </script>
 
 <main>
@@ -12,7 +14,7 @@
         {#if rec.question.images}
           <div class="images">
             {#each rec.question.images as img}
-              <img src={img} alt="" transition:fade />
+              <img src={img} alt="" transition:fade on:click={() => (lightbox = img)} />
             {/each}
           </div>
         {/if}
@@ -40,6 +42,11 @@
     {/each}
   {:else}
     <p>No results.</p>
+  {/if}
+  {#if lightbox}
+    <div class="lightbox" on:click={() => (lightbox = null)} transition:fade>
+      <img src={lightbox} alt="enlarged" />
+    </div>
   {/if}
 </main>
 

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -8,8 +8,9 @@
 <main>
   <h1>Exam Review</h1>
   {#if $lastResult}
-    {#each $lastResult.records as rec (rec.question.id)}
-      <div class="question" transition:fade>
+{#each $lastResult.records as rec, i (rec.question.id)}
+      <article class="review-card" transition:fade>
+        <h2>Question {i + 1}</h2>
         <p>{rec.question.question}</p>
         {#if rec.question.images}
           <div class="images">
@@ -44,7 +45,7 @@
           <p>Correct answer: {rec.question.answer}</p>
           <p>Your answer: {rec.answer}</p>
         {/if}
-      </div>
+      </article>
     {/each}
   {:else}
     <p>No results.</p>

--- a/src/routes/review/[idx]/+page.svelte
+++ b/src/routes/review/[idx]/+page.svelte
@@ -21,7 +21,13 @@
         {#if rec.question.images}
           <div class="images">
             {#each rec.question.images as img}
-              <img src={img} alt="" transition:fade on:click={() => (lightbox = img)} />
+              <button
+                type="button"
+                class="img-thumb"
+                on:click={() => (lightbox = img)}
+              >
+                <img src={img} alt="" transition:fade />
+              </button>
             {/each}
           </div>
         {/if}
@@ -51,9 +57,14 @@
     <p>Exam not found.</p>
   {/if}
   {#if lightbox}
-    <div class="lightbox" on:click={() => (lightbox = null)} transition:fade>
+    <button
+      type="button"
+      class="lightbox"
+      on:click={() => (lightbox = null)}
+      transition:fade
+    >
       <img src={lightbox} alt="enlarged" />
-    </div>
+    </button>
   {/if}
 </main>
 

--- a/src/routes/review/[idx]/+page.svelte
+++ b/src/routes/review/[idx]/+page.svelte
@@ -15,8 +15,9 @@
 <main>
   <h1>Exam Review</h1>
   {#if $entry}
-    {#each $entry.records as rec (rec.question.id)}
-      <div class="question" transition:fade>
+    {#each $entry.records as rec, i (rec.question.id)}
+      <article class="review-card" transition:fade>
+        <h2>Question {i + 1}</h2>
         <p>{rec.question.question}</p>
         {#if rec.question.images}
           <div class="images">
@@ -51,7 +52,7 @@
           <p>Correct answer: {rec.question.answer}</p>
           <p>Your answer: {rec.answer}</p>
         {/if}
-      </div>
+      </article>
     {/each}
   {:else}
     <p>Exam not found.</p>

--- a/src/routes/review/[idx]/+page.svelte
+++ b/src/routes/review/[idx]/+page.svelte
@@ -33,21 +33,30 @@
           </div>
         {/if}
         {#if rec.question.options}
-          <ul>
+          <div class="options">
             {#each Object.entries(rec.question.options) as [key, text]}
-              <li
-                class={
-                  rec.question.answer == key
-                    ? 'correct'
-                    : rec.answer == key && !rec.correct
-                    ? 'wrong'
-                    : ''
+              <button
+                type="button"
+                class="option-btn"
+                class:correct={
+                  Array.isArray(rec.question.answer)
+                    ? rec.question.answer.includes(key)
+                    : rec.question.answer === key
                 }
+                class:wrong={
+                  (Array.isArray(rec.answer)
+                    ? rec.answer.includes(key)
+                    : rec.answer === key) &&
+                  !(Array.isArray(rec.question.answer)
+                    ? rec.question.answer.includes(key)
+                    : rec.question.answer === key)
+                }
+                disabled
               >
                 {key}. {text}
-              </li>
+              </button>
             {/each}
-          </ul>
+          </div>
         {:else}
           <p>Correct answer: {rec.question.answer}</p>
           <p>Your answer: {rec.answer}</p>

--- a/src/routes/review/[idx]/+page.svelte
+++ b/src/routes/review/[idx]/+page.svelte
@@ -2,6 +2,7 @@
   import { page } from '$app/stores';
   import { derived } from 'svelte/store';
   import { history } from '$lib/stores/results';
+  import { fade } from 'svelte/transition';
 
   // Index of the history entry derived from the route parameter
   const idx = derived(page, ($p) => parseInt($p.params.idx));
@@ -13,8 +14,15 @@
   <h1>Exam Review</h1>
   {#if $entry}
     {#each $entry.records as rec (rec.question.id)}
-      <div class="question">
+      <div class="question" transition:fade>
         <p>{rec.question.question}</p>
+        {#if rec.question.images}
+          <div class="images">
+            {#each rec.question.images as img}
+              <img src={img} alt="" transition:fade />
+            {/each}
+          </div>
+        {/if}
         {#if rec.question.options}
           <ul>
             {#each Object.entries(rec.question.options) as [key, text]}
@@ -41,5 +49,6 @@
     <p>Exam not found.</p>
   {/if}
 </main>
+
 
 

--- a/src/routes/review/[idx]/+page.svelte
+++ b/src/routes/review/[idx]/+page.svelte
@@ -4,6 +4,8 @@
   import { history } from '$lib/stores/results';
   import { fade } from 'svelte/transition';
 
+  let lightbox: string | null = null;
+
   // Index of the history entry derived from the route parameter
   const idx = derived(page, ($p) => parseInt($p.params.idx));
   // The history entry selected for review
@@ -19,7 +21,7 @@
         {#if rec.question.images}
           <div class="images">
             {#each rec.question.images as img}
-              <img src={img} alt="" transition:fade />
+              <img src={img} alt="" transition:fade on:click={() => (lightbox = img)} />
             {/each}
           </div>
         {/if}
@@ -47,6 +49,11 @@
     {/each}
   {:else}
     <p>Exam not found.</p>
+  {/if}
+  {#if lightbox}
+    <div class="lightbox" on:click={() => (lightbox = null)} transition:fade>
+      <img src={lightbox} alt="enlarged" />
+    </div>
   {/if}
 </main>
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import { dataDir, themeColor, darkMode } from '$lib/stores/settings';
+  import { dataDir, darkMode } from '$lib/stores/settings';
   import { getQuestionBank } from '$lib/stores/questions';
   import { history, saveHistory } from '$lib/stores/results';
 
   let dir = '';
   $: dir = $dataDir;
-  let color = $themeColor;
   let dark = $darkMode;
 
   /**
@@ -13,10 +12,6 @@
    */
   function updateDir() {
     dataDir.set(dir);
-  }
-
-  function updateColor() {
-    themeColor.set(color);
   }
 
   function updateDark() {
@@ -58,9 +53,6 @@
   <button on:click={updateDir}>Save Path</button>
   <button on:click={exportQuestions}>Export Question Bank</button>
   <button on:click={exportHistory}>Export History</button>
-  <label>
-    Theme Color <input type="color" bind:value={color} on:change={updateColor} />
-  </label>
   <label>
     Dark Mode <input type="checkbox" bind:checked={dark} on:change={updateDark} />
   </label>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,16 +1,26 @@
 <script lang="ts">
-  import { dataDir } from '$lib/stores/settings';
+  import { dataDir, themeColor, darkMode } from '$lib/stores/settings';
   import { getQuestionBank } from '$lib/stores/questions';
   import { history, saveHistory } from '$lib/stores/results';
 
   let dir = '';
   $: dir = $dataDir;
+  let color = $themeColor;
+  let dark = $darkMode;
 
   /**
    * Persist the input data directory path to the settings store.
    */
   function updateDir() {
     dataDir.set(dir);
+  }
+
+  function updateColor() {
+    themeColor.set(color);
+  }
+
+  function updateDark() {
+    darkMode.set(dark);
   }
 
   /**
@@ -48,5 +58,11 @@
   <button on:click={updateDir}>Save Path</button>
   <button on:click={exportQuestions}>Export Question Bank</button>
   <button on:click={exportHistory}>Export History</button>
+  <label>
+    Theme Color <input type="color" bind:value={color} on:change={updateColor} />
+  </label>
+  <label>
+    Dark Mode <input type="checkbox" bind:checked={dark} on:change={updateDark} />
+  </label>
 </main>
 

--- a/static/app.css
+++ b/static/app.css
@@ -1,16 +1,23 @@
 :root {
-  --background: #fff;
-  --text: #000;
-  --code-bg: #f0f0f0;
-  --nav-text: #fff;
-  --primary: #00AA90; /* Nippon color Aotake */
+  --c1: #FAF7F3;
+  --c2: #F0E4D3;
+  --c3: #DCC5B2;
+  --c4: #D9A299;
+  --background: var(--c1);
+  --text: #333;
+  --code-bg: var(--c2);
+  --nav-bg: var(--c3);
+  --nav-text: #000;
+  --primary: var(--c4);
 }
 
 .dark {
-  --background: #000;
+  --background: #222;
   --text: #fff;
-  --code-bg: #333;
-  --primary: #007B65;
+  --code-bg: #444;
+  --nav-bg: #111;
+  --nav-text: #fff;
+  --primary: var(--c3);
 }
 
 body {
@@ -34,7 +41,7 @@ nav.main-nav {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: var(--primary);
+  background: var(--nav-bg);
   color: var(--nav-text);
   padding: 0.5rem 1rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -42,16 +49,19 @@ nav.main-nav {
 
 nav.main-nav .links {
   display: flex;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 nav.main-nav a {
   color: var(--nav-text);
   text-decoration: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
 }
 
 nav.main-nav a:hover {
-  text-decoration: underline;
+  background: var(--primary);
+  color: var(--nav-text);
 }
 
 nav.main-nav .brand {
@@ -60,44 +70,6 @@ nav.main-nav .brand {
 }
 
 
-.nav-btn {
-  outline: 0;
-  border: none;
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 50%;
-  background: transparent;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--nav-text);
-  position: relative;
-  cursor: pointer;
-  overflow: hidden;
-  transition: transform 0.3s;
-}
-
-.nav-btn:hover {
-  transform: translateY(-3px);
-}
-
-.nav-btn::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: rgba(255, 255, 255, 0.3);
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 0.3s;
-}
-
-.nav-btn:hover::after {
-  transform: scaleX(1);
-}
-
-.icon {
-  font-size: 20px;
-}
 
 input,
 select,
@@ -113,15 +85,13 @@ select {
 }
 
 button {
-  width: 6.5em;
-  height: 2.3em;
   margin: 0.5em;
   background: var(--primary);
   color: var(--nav-text);
   border: none;
-  border-radius: 0.625em;
-  font-size: 20px;
-  font-weight: bold;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 600;
   cursor: pointer;
   position: relative;
   z-index: 1;
@@ -290,5 +260,5 @@ pre {
   transition: background 0.3s;
 }
 .dashboard .quick a:hover {
-  background: #055C47;
+  background: var(--nav-bg);
 }

--- a/static/app.css
+++ b/static/app.css
@@ -9,6 +9,7 @@
   --nav-bg: var(--c3);
   --nav-text: #000;
   --primary: var(--c4);
+  --shadow: rgba(217, 162, 153, 0.5);
 }
 
 .dark {
@@ -18,6 +19,7 @@
   --nav-bg: #111;
   --nav-text: #fff;
   --primary: var(--c3);
+  --shadow: rgba(217, 162, 153, 0.5);
 }
 
 body {
@@ -79,7 +81,7 @@ nav.main-nav .nav-btn:hover {
   letter-spacing: 2px;
   background: var(--primary);
   color: #fff;
-  box-shadow: 0 7px 29px rgba(93, 24, 220, 0.5);
+  box-shadow: 0 7px 29px var(--shadow);
 }
 
 nav.main-nav .nav-btn::after {
@@ -87,6 +89,7 @@ nav.main-nav .nav-btn::after {
   background: var(--primary);
   position: absolute;
   z-index: -1;
+  border-radius: inherit;
   left: 0;
   right: 0;
   top: 0;
@@ -144,7 +147,7 @@ button:hover {
   letter-spacing: 2px;
   background: var(--primary);
   color: #fff;
-  box-shadow: 0 7px 29px rgba(93, 24, 220, 0.5);
+  box-shadow: 0 7px 29px var(--shadow);
 }
 
 button:active {
@@ -290,15 +293,6 @@ pre {
   flex-wrap: wrap;
 }
 .dashboard .quick a {
-  background: var(--primary);
-  color: var(--nav-text);
-  padding: 0.75em 1.2em;
-  border-radius: 4px;
-  text-decoration: none;
-  transition: background 0.3s;
-}
-
-.dashboard .quick a:hover {
-  background: var(--nav-bg);
+  margin: 0.25em;
 }
 

--- a/static/app.css
+++ b/static/app.css
@@ -52,13 +52,13 @@ nav.main-nav {
 nav.main-nav .nav-buttons {
   display: flex;
   background: var(--primary);
-  height: 40px;
   align-items: center;
   justify-content: space-around;
   border-radius: 10px;
   padding: 0 0.5rem;
   flex-wrap: wrap;
   gap: 0.25rem;
+  min-height: 40px;
 }
 
 nav.main-nav .nav-btn {
@@ -128,6 +128,12 @@ nav.main-nav .nav-btn .label {
   }
   nav.main-nav .nav-btn .label {
     display: none;
+  }
+  nav.main-nav .nav-buttons {
+    padding: 0.25rem;
+  }
+  nav.main-nav .brand {
+    font-size: 1rem;
   }
 }
 

--- a/static/app.css
+++ b/static/app.css
@@ -1,14 +1,13 @@
 :root {
-  --primary: #3f51b5;
-  --background: #fafafa;
-  --text: #333;
-  --code-bg: #eee;
+  --background: #fff;
+  --text: #000;
+  --code-bg: #f0f0f0;
   --nav-text: #fff;
 }
 
 .dark {
-  --background: #121212;
-  --text: #eee;
+  --background: #000;
+  --text: #fff;
   --code-bg: #333;
 }
 
@@ -33,7 +32,7 @@ nav.main-nav {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: var(--primary);
+  background: #000;
   color: var(--nav-text);
   padding: 0.5rem 1rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -58,6 +57,40 @@ nav.main-nav .brand {
   font-size: 1.2rem;
 }
 
+.button-container {
+  display: flex;
+  background-color: #000;
+  width: 250px;
+  height: 40px;
+  align-items: center;
+  justify-content: space-around;
+  border-radius: 10px;
+  box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
+}
+
+.button {
+  outline: 0 !important;
+  border: 0 !important;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  transition: all ease-in-out 0.3s;
+  cursor: pointer;
+}
+
+.button:hover {
+  transform: translateY(-3px);
+}
+
+.icon {
+  font-size: 20px;
+}
+
 input,
 select,
 button {
@@ -72,14 +105,42 @@ select {
 }
 
 button {
-  cursor: pointer;
-  background: var(--primary);
-  border: none;
+  width: 6.5em;
+  height: 2.3em;
+  margin: 0.5em;
+  background: #000;
   color: #fff;
+  border: none;
+  border-radius: 0.625em;
+  font-size: 20px;
+  font-weight: bold;
+  cursor: pointer;
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  transition: transform 0.3s;
 }
 
 button:hover {
-  opacity: 0.9;
+  color: #000;
+  transform: translateY(-2px);
+}
+
+button::after {
+  content: "";
+  background: #fff;
+  position: absolute;
+  z-index: -1;
+  left: -20%;
+  right: -20%;
+  top: 0;
+  bottom: 0;
+  transform: skewX(-45deg) scale(0, 1);
+  transition: all 0.5s;
+}
+
+button:hover::after {
+  transform: skewX(-45deg) scale(1, 1);
 }
 
 label {
@@ -123,10 +184,13 @@ td {
   margin-bottom: 0.5rem;
 }
 .images button {
-  border: none;
-  padding: 0;
+  width: auto;
+  height: auto;
+  margin: 0;
   background: none;
+  border: none;
   cursor: pointer;
+  color: inherit;
 }
 .images img {
   display: block;
@@ -146,12 +210,21 @@ td {
   position: absolute;
   top: 0;
   right: 0;
+  width: auto;
+  height: auto;
+  margin: 0;
+  background: none;
+  border: none;
 }
 .img-wrapper .thumb {
-  border: none;
+  width: auto;
+  height: auto;
+  margin: 0;
   background: none;
+  border: none;
   padding: 0;
   cursor: pointer;
+  position: static;
 }
 
 pre {
@@ -171,6 +244,8 @@ pre {
   z-index: 1000;
   border: none;
   padding: 0;
+  width: 100%;
+  height: 100%;
 }
 .lightbox img {
   max-width: 90%;
@@ -186,10 +261,11 @@ pre {
 .dashboard .stats div {
   flex: 1;
   text-align: center;
-  background: var(--primary);
+  background: #000;
   color: #fff;
   padding: 1rem;
   border-radius: 6px;
+  transition: transform 0.3s;
 }
 .dashboard .quick {
   margin-top: 1rem;
@@ -198,12 +274,13 @@ pre {
   flex-wrap: wrap;
 }
 .dashboard .quick a {
-  background: var(--primary);
+  background: #000;
   color: #fff;
   padding: 0.75em 1.2em;
   border-radius: 4px;
   text-decoration: none;
+  transition: background 0.3s;
 }
 .dashboard .quick a:hover {
-  opacity: 0.9;
+  background: #444;
 }

--- a/static/app.css
+++ b/static/app.css
@@ -61,6 +61,13 @@ nav.main-nav .nav-buttons {
   min-height: 40px;
 }
 
+nav.main-nav .nav-buttons.compact .label {
+  display: none;
+}
+nav.main-nav .nav-buttons.compact {
+  padding: 0.25rem;
+}
+
 nav.main-nav .nav-btn {
   text-decoration: none;
   color: var(--nav-text);
@@ -122,7 +129,7 @@ nav.main-nav .nav-btn .label {
   display: inline;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 1200px) {
   nav.main-nav .nav-btn {
     padding: 0.5em;
   }

--- a/static/app.css
+++ b/static/app.css
@@ -56,7 +56,8 @@ nav.main-nav .nav-buttons {
   justify-content: space-around;
   border-radius: 10px;
   padding: 0 0.5rem;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  overflow-x: auto;
   gap: 0.25rem;
   min-height: 40px;
 }

--- a/static/app.css
+++ b/static/app.css
@@ -247,7 +247,8 @@ td {
 }
 
 .option-btn.selected {
-  background: #eee;
+  background: #000;
+  color: #fff;
 }
 
 .option-btn.correct {

--- a/static/app.css
+++ b/static/app.css
@@ -47,21 +47,54 @@ nav.main-nav {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-nav.main-nav .links {
+nav.main-nav .nav-buttons {
   display: flex;
-  gap: 0.75rem;
-}
-
-nav.main-nav a {
-  color: var(--nav-text);
-  text-decoration: none;
-  padding: 0.25rem 0.5rem;
-  border-radius: 4px;
-}
-
-nav.main-nav a:hover {
   background: var(--primary);
-  color: var(--nav-text);
+  height: 40px;
+  align-items: center;
+  justify-content: space-around;
+  border-radius: 10px;
+  padding: 0 0.5rem;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.35), 0 10px 15px rgba(0, 0, 0, 0.1);
+}
+
+nav.main-nav .nav-btn {
+  text-decoration: none;
+  color: #fff;
+  font-size: 1rem;
+  font-weight: bold;
+  position: relative;
+  margin: 0 0.25rem;
+  padding: 0 0.75rem;
+  height: 2.3em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.625em;
+  overflow: hidden;
+  transition: transform 0.3s;
+}
+
+nav.main-nav .nav-btn:hover {
+  transform: translateY(-3px);
+  color: var(--primary);
+}
+
+nav.main-nav .nav-btn::after {
+  content: "";
+  background: #fff;
+  position: absolute;
+  z-index: -1;
+  left: -20%;
+  right: -20%;
+  top: 0;
+  bottom: 0;
+  transform: skewX(-45deg) scale(0, 1);
+  transition: all 0.5s;
+}
+
+nav.main-nav .nav-btn:hover::after {
+  transform: skewX(-45deg) scale(1, 1);
 }
 
 nav.main-nav .brand {
@@ -259,41 +292,9 @@ pre {
   text-decoration: none;
   transition: background 0.3s;
 }
+
 .dashboard .quick a:hover {
   background: var(--nav-bg);
-}
-
-nav.bottom-nav {
-  position: fixed;
-  bottom: 1rem;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  gap: 0.5rem;
-  padding: 0.5rem;
-  background: rgba(255, 255, 255, 0.15);
-  backdrop-filter: blur(8px);
-  border-radius: 3rem;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-}
-nav.bottom-nav a {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--nav-text);
-  text-decoration: none;
-  transition: transform 0.2s, background 0.2s;
-}
-nav.bottom-nav a:hover {
-  transform: translateY(-2px);
-  background: rgba(255, 255, 255, 0.25);
-}
-nav.bottom-nav svg {
-  width: 24px;
-  height: 24px;
 }
 
 .dashboard {

--- a/static/app.css
+++ b/static/app.css
@@ -211,6 +211,12 @@ td {
   margin-bottom: 1em;
 }
 
+.options {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 0.5rem;
+}
+
 .review-card {
   margin-bottom: 1rem;
   padding: 1rem;
@@ -220,11 +226,36 @@ td {
 }
 
 .correct {
-  color: green;
+  background: #c8e6c9;
 }
 
 .wrong {
-  color: red;
+  background: #f6caca;
+}
+
+.option-btn {
+  display: block;
+  width: 100%;
+  padding: 0.5em 1em;
+  margin: 0.25em 0;
+  border: 1px solid #ccc;
+  background: #fff;
+  border-radius: 6px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.option-btn.selected {
+  background: #eee;
+}
+
+.option-btn.correct {
+  background: #c8e6c9;
+}
+
+.option-btn.wrong {
+  background: #f6caca;
 }
 
 .images {

--- a/static/app.css
+++ b/static/app.css
@@ -31,10 +31,17 @@ h1 {
 
 nav.main-nav {
   display: flex;
-  gap: 1rem;
-  background-color: var(--primary);
+  justify-content: space-between;
+  align-items: center;
+  background: var(--primary);
   color: var(--nav-text);
-  padding: 0.75rem 1rem;
+  padding: 0.5rem 1rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+nav.main-nav .links {
+  display: flex;
+  gap: 1rem;
 }
 
 nav.main-nav a {
@@ -44,6 +51,11 @@ nav.main-nav a {
 
 nav.main-nav a:hover {
   text-decoration: underline;
+}
+
+nav.main-nav .brand {
+  font-weight: bold;
+  font-size: 1.2rem;
 }
 
 input,
@@ -130,10 +142,16 @@ td {
   position: relative;
   display: inline-block;
 }
-.img-wrapper button {
+.img-wrapper .remove {
   position: absolute;
   top: 0;
   right: 0;
+}
+.img-wrapper .thumb {
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
 }
 
 pre {

--- a/static/app.css
+++ b/static/app.css
@@ -44,7 +44,6 @@ nav.main-nav {
   background: var(--nav-bg);
   color: var(--nav-text);
   padding: 0.5rem 1rem;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 nav.main-nav .nav-buttons {
@@ -55,46 +54,55 @@ nav.main-nav .nav-buttons {
   justify-content: space-around;
   border-radius: 10px;
   padding: 0 0.5rem;
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.35), 0 10px 15px rgba(0, 0, 0, 0.1);
 }
 
 nav.main-nav .nav-btn {
   text-decoration: none;
-  color: #fff;
-  font-size: 1rem;
+  color: var(--nav-text);
+  font-size: 0.9rem;
   font-weight: bold;
   position: relative;
   margin: 0 0.25rem;
-  padding: 0 0.75rem;
-  height: 2.3em;
+  padding: 0.5em 1.25em;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.625em;
-  overflow: hidden;
-  transition: transform 0.3s;
+  border-radius: 50px;
+  background: #fff;
+  box-shadow: 0 0 8px rgb(0 0 0 / 5%);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  transition: all 0.5s ease;
 }
 
 nav.main-nav .nav-btn:hover {
-  transform: translateY(-3px);
-  color: var(--primary);
+  letter-spacing: 2px;
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 0 7px 29px rgba(93, 24, 220, 0.5);
 }
 
 nav.main-nav .nav-btn::after {
   content: "";
-  background: #fff;
+  background: var(--primary);
   position: absolute;
   z-index: -1;
-  left: -20%;
-  right: -20%;
+  left: 0;
+  right: 0;
   top: 0;
   bottom: 0;
-  transform: skewX(-45deg) scale(0, 1);
-  transition: all 0.5s;
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
 }
 
 nav.main-nav .nav-btn:hover::after {
-  transform: skewX(-45deg) scale(1, 1);
+  transform: scaleX(1);
+}
+
+nav.main-nav .nav-btn:active {
+  transform: translateY(4px);
+  box-shadow: none;
 }
 
 nav.main-nav .brand {
@@ -108,50 +116,41 @@ input,
 select,
 button {
   font-size: 1rem;
-  padding: 0.4em 0.6em;
-  margin: 0.25em 0;
-  border-radius: 4px;
 }
 input,
 select {
+  padding: 0.4em 0.6em;
+  margin: 0.25em 0;
+  border-radius: 4px;
   border: 1px solid #ccc;
 }
 
 button {
+  padding: 0.6em 1.25em;
   margin: 0.5em;
-  background: var(--primary);
-  color: var(--nav-text);
   border: none;
-  border-radius: 4px;
-  font-size: 1rem;
-  font-weight: 600;
+  border-radius: 50px;
+  background: #fff;
+  color: var(--nav-text);
+  box-shadow: 0 0 8px rgb(0 0 0 / 5%);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-size: 0.9rem;
   cursor: pointer;
-  position: relative;
-  z-index: 1;
-  overflow: hidden;
-  transition: transform 0.3s;
+  transition: all 0.5s ease;
 }
 
 button:hover {
-  color: var(--primary);
-  transform: translateY(-2px);
+  letter-spacing: 2px;
+  background: var(--primary);
+  color: #fff;
+  box-shadow: 0 7px 29px rgba(93, 24, 220, 0.5);
 }
 
-button::after {
-  content: "";
-  background: var(--nav-text);
-  position: absolute;
-  z-index: -1;
-  left: -20%;
-  right: -20%;
-  top: 0;
-  bottom: 0;
-  transform: skewX(-45deg) scale(0, 1);
-  transition: all 0.5s;
-}
-
-button:hover::after {
-  transform: skewX(-45deg) scale(1, 1);
+button:active {
+  transform: translateY(4px);
+  box-shadow: none;
+  transition: 100ms;
 }
 
 label {
@@ -200,6 +199,9 @@ td {
   margin: 0;
   background: none;
   border: none;
+  padding: 0;
+  box-shadow: none;
+  border-radius: 0;
   cursor: pointer;
   color: inherit;
 }
@@ -226,6 +228,8 @@ td {
   margin: 0;
   background: none;
   border: none;
+  padding: 0;
+  box-shadow: none;
 }
 .img-wrapper .thumb {
   width: auto;
@@ -234,6 +238,7 @@ td {
   background: none;
   border: none;
   padding: 0;
+  box-shadow: none;
   cursor: pointer;
   position: static;
 }
@@ -297,48 +302,3 @@ pre {
   background: var(--nav-bg);
 }
 
-.dashboard {
-  position: relative;
-}
-.dashboard .shapes {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  overflow: hidden;
-  z-index: -1;
-}
-.dashboard .shapes div {
-  position: absolute;
-  background: var(--primary);
-  animation: float 12s linear infinite;
-}
-.dashboard .triangle {
-  width: 0;
-  height: 0;
-  border-left: 20px solid transparent;
-  border-right: 20px solid transparent;
-  border-bottom: 30px solid var(--primary);
-  top: 20%;
-  left: 10%;
-}
-.dashboard .circle {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  top: 40%;
-  right: 20%;
-  animation-delay: 2s;
-}
-.dashboard .square {
-  width: 30px;
-  height: 30px;
-  bottom: 30%;
-  right: 60%;
-  transform: rotate(45deg);
-  animation-delay: 6s;
-}
-@keyframes float {
-  0%,100% { transform: translate(0,0); }
-  25%,75% { transform: translate(30px,10px); }
-  50% { transform: translate(60px,20px); }
-}

--- a/static/app.css
+++ b/static/app.css
@@ -3,12 +3,14 @@
   --text: #000;
   --code-bg: #f0f0f0;
   --nav-text: #fff;
+  --primary: #00AA90; /* Nippon color Aotake */
 }
 
 .dark {
   --background: #000;
   --text: #fff;
   --code-bg: #333;
+  --primary: #007B65;
 }
 
 body {
@@ -32,7 +34,7 @@ nav.main-nav {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: #000;
+  background: var(--primary);
   color: var(--nav-text);
   padding: 0.5rem 1rem;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -57,34 +59,40 @@ nav.main-nav .brand {
   font-size: 1.2rem;
 }
 
-.button-container {
-  display: flex;
-  background-color: #000;
-  width: 250px;
-  height: 40px;
-  align-items: center;
-  justify-content: space-around;
-  border-radius: 10px;
-  box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
-}
 
-.button {
-  outline: 0 !important;
-  border: 0 !important;
-  width: 40px;
-  height: 40px;
+.nav-btn {
+  outline: 0;
+  border: none;
+  width: 2.5rem;
+  height: 2.5rem;
   border-radius: 50%;
-  background-color: transparent;
+  background: transparent;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #fff;
-  transition: all ease-in-out 0.3s;
+  color: var(--nav-text);
+  position: relative;
   cursor: pointer;
+  overflow: hidden;
+  transition: transform 0.3s;
 }
 
-.button:hover {
+.nav-btn:hover {
   transform: translateY(-3px);
+}
+
+.nav-btn::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.3);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s;
+}
+
+.nav-btn:hover::after {
+  transform: scaleX(1);
 }
 
 .icon {
@@ -108,8 +116,8 @@ button {
   width: 6.5em;
   height: 2.3em;
   margin: 0.5em;
-  background: #000;
-  color: #fff;
+  background: var(--primary);
+  color: var(--nav-text);
   border: none;
   border-radius: 0.625em;
   font-size: 20px;
@@ -122,13 +130,13 @@ button {
 }
 
 button:hover {
-  color: #000;
+  color: var(--primary);
   transform: translateY(-2px);
 }
 
 button::after {
   content: "";
-  background: #fff;
+  background: var(--nav-text);
   position: absolute;
   z-index: -1;
   left: -20%;
@@ -261,8 +269,8 @@ pre {
 .dashboard .stats div {
   flex: 1;
   text-align: center;
-  background: #000;
-  color: #fff;
+  background: var(--primary);
+  color: var(--nav-text);
   padding: 1rem;
   border-radius: 6px;
   transition: transform 0.3s;
@@ -274,13 +282,13 @@ pre {
   flex-wrap: wrap;
 }
 .dashboard .quick a {
-  background: #000;
-  color: #fff;
+  background: var(--primary);
+  color: var(--nav-text);
   padding: 0.75em 1.2em;
   border-radius: 4px;
   text-decoration: none;
   transition: background 0.3s;
 }
 .dashboard .quick a:hover {
-  background: #444;
+  background: #055C47;
 }

--- a/static/app.css
+++ b/static/app.css
@@ -33,6 +33,7 @@ main {
   max-width: 800px;
   margin: auto;
   padding: 1rem;
+  overflow-x: auto;
 }
 
 h1 {
@@ -56,6 +57,8 @@ nav.main-nav .nav-buttons {
   justify-content: space-around;
   border-radius: 10px;
   padding: 0 0.5rem;
+  flex-wrap: wrap;
+  gap: 0.25rem;
 }
 
 nav.main-nav .nav-btn {

--- a/static/app.css
+++ b/static/app.css
@@ -315,6 +315,73 @@ td {
   position: static;
 }
 
+/* option editing checkboxes */
+.option-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.option-check {
+  position: relative;
+  width: 1.3em;
+  height: 1.3em;
+}
+
+.option-check input {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.option-check .mark {
+  position: absolute;
+  inset: 0;
+  background: #ccc;
+  border-radius: 0.25em;
+  box-shadow: 2px 2px #888;
+}
+
+.option-check input:checked + .mark {
+  background: #5ee429;
+}
+
+.option-check.checkbox .mark:after,
+.option-check.radio .mark:after {
+  content: "";
+  position: absolute;
+  display: none;
+}
+
+.option-check.checkbox input:checked + .mark:after {
+  display: block;
+  left: 0.4em;
+  top: 0.2em;
+  width: 0.25em;
+  height: 0.5em;
+  border: solid white;
+  border-width: 0 0.15em 0.15em 0;
+  transform: rotate(45deg);
+}
+
+.option-check.radio .mark {
+  border-radius: 50%;
+}
+
+.option-check.radio input:checked + .mark:after {
+  display: block;
+  top: 0.35em;
+  left: 0.35em;
+  width: 0.6em;
+  height: 0.6em;
+  background: white;
+  border-radius: 50%;
+}
+
 pre {
   background: var(--code-bg);
   color: var(--text);

--- a/static/app.css
+++ b/static/app.css
@@ -110,6 +110,12 @@ td {
   gap: 0.5rem;
   margin-bottom: 0.5rem;
 }
+.images button {
+  border: none;
+  padding: 0;
+  background: none;
+  cursor: pointer;
+}
 .images img {
   display: block;
   max-width: 200px;
@@ -145,6 +151,8 @@ pre {
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  border: none;
+  padding: 0;
 }
 .lightbox img {
   max-width: 90%;

--- a/static/app.css
+++ b/static/app.css
@@ -1,8 +1,19 @@
+:root {
+  --primary: #3f51b5;
+  --background: #fafafa;
+  --text: #333;
+}
+
+.dark {
+  --background: #121212;
+  --text: #eee;
+}
+
 body {
   margin: 0;
   font-family: system-ui, sans-serif;
-  background-color: #fafafa;
-  color: #333;
+  background: var(--background);
+  color: var(--text);
 }
 
 main {
@@ -18,12 +29,12 @@ h1 {
 nav.main-nav {
   display: flex;
   gap: 1rem;
-  background-color: #3f51b5;
+  background-color: var(--primary);
   padding: 0.75rem 1rem;
 }
 
 nav.main-nav a {
-  color: white;
+  color: #fff;
   text-decoration: none;
 }
 
@@ -37,10 +48,22 @@ button {
   font-size: 1rem;
   padding: 0.4em 0.6em;
   margin: 0.25em 0;
+  border-radius: 4px;
+}
+input,
+select {
+  border: 1px solid #ccc;
 }
 
 button {
   cursor: pointer;
+  background: var(--primary);
+  border: none;
+  color: #fff;
+}
+
+button:hover {
+  opacity: 0.9;
 }
 
 label {
@@ -75,4 +98,30 @@ td {
 
 .wrong {
   color: red;
+}
+
+.images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.images img {
+  display: block;
+  max-width: 200px;
+  margin-right: 0.5rem;
+}
+.thumbs img {
+  max-width: 80px;
+  max-height: 80px;
+}
+
+.img-wrapper {
+  position: relative;
+  display: inline-block;
+}
+.img-wrapper button {
+  position: absolute;
+  top: 0;
+  right: 0;
 }

--- a/static/app.css
+++ b/static/app.css
@@ -61,12 +61,6 @@ nav.main-nav .nav-buttons {
   min-height: 40px;
 }
 
-nav.main-nav .nav-buttons.compact .label {
-  display: none;
-}
-nav.main-nav .nav-buttons.compact {
-  padding: 0.25rem;
-}
 
 nav.main-nav .nav-btn {
   text-decoration: none;
@@ -129,19 +123,17 @@ nav.main-nav .nav-btn .label {
   display: inline;
 }
 
-@media (max-width: 1200px) {
-  nav.main-nav .nav-btn {
-    padding: 0.5em;
-  }
-  nav.main-nav .nav-btn .label {
-    display: none;
-  }
-  nav.main-nav .nav-buttons {
-    padding: 0.25rem;
-  }
-  nav.main-nav .brand {
-    font-size: 1rem;
-  }
+nav.main-nav.compact .nav-btn {
+  padding: 0.5em;
+}
+nav.main-nav .nav-buttons.compact .label {
+  display: none;
+}
+nav.main-nav .nav-buttons.compact {
+  padding: 0.25rem;
+}
+nav.main-nav.compact .brand {
+  font-size: 1rem;
 }
 
 nav.main-nav .brand {

--- a/static/app.css
+++ b/static/app.css
@@ -262,3 +262,82 @@ pre {
 .dashboard .quick a:hover {
   background: var(--nav-bg);
 }
+
+nav.bottom-nav {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(8px);
+  border-radius: 3rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+nav.bottom-nav a {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--nav-text);
+  text-decoration: none;
+  transition: transform 0.2s, background 0.2s;
+}
+nav.bottom-nav a:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.25);
+}
+nav.bottom-nav svg {
+  width: 24px;
+  height: 24px;
+}
+
+.dashboard {
+  position: relative;
+}
+.dashboard .shapes {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: -1;
+}
+.dashboard .shapes div {
+  position: absolute;
+  background: var(--primary);
+  animation: float 12s linear infinite;
+}
+.dashboard .triangle {
+  width: 0;
+  height: 0;
+  border-left: 20px solid transparent;
+  border-right: 20px solid transparent;
+  border-bottom: 30px solid var(--primary);
+  top: 20%;
+  left: 10%;
+}
+.dashboard .circle {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  top: 40%;
+  right: 20%;
+  animation-delay: 2s;
+}
+.dashboard .square {
+  width: 30px;
+  height: 30px;
+  bottom: 30%;
+  right: 60%;
+  transform: rotate(45deg);
+  animation-delay: 6s;
+}
+@keyframes float {
+  0%,100% { transform: translate(0,0); }
+  25%,75% { transform: translate(30px,10px); }
+  50% { transform: translate(60px,20px); }
+}

--- a/static/app.css
+++ b/static/app.css
@@ -2,11 +2,14 @@
   --primary: #3f51b5;
   --background: #fafafa;
   --text: #333;
+  --code-bg: #eee;
+  --nav-text: #fff;
 }
 
 .dark {
   --background: #121212;
   --text: #eee;
+  --code-bg: #333;
 }
 
 body {
@@ -30,11 +33,12 @@ nav.main-nav {
   display: flex;
   gap: 1rem;
   background-color: var(--primary);
+  color: var(--nav-text);
   padding: 0.75rem 1rem;
 }
 
 nav.main-nav a {
-  color: #fff;
+  color: var(--nav-text);
   text-decoration: none;
 }
 
@@ -124,4 +128,56 @@ td {
   position: absolute;
   top: 0;
   right: 0;
+}
+
+pre {
+  background: var(--code-bg);
+  color: var(--text);
+  padding: 1em;
+  overflow-x: auto;
+}
+
+.lightbox {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.lightbox img {
+  max-width: 90%;
+  max-height: 90%;
+  box-shadow: 0 0 10px #000;
+}
+
+.dashboard .stats {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.dashboard .stats div {
+  flex: 1;
+  text-align: center;
+  background: var(--primary);
+  color: #fff;
+  padding: 1rem;
+  border-radius: 6px;
+}
+.dashboard .quick {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.dashboard .quick a {
+  background: var(--primary);
+  color: #fff;
+  padding: 0.75em 1.2em;
+  border-radius: 4px;
+  text-decoration: none;
+}
+.dashboard .quick a:hover {
+  opacity: 0.9;
 }

--- a/static/app.css
+++ b/static/app.css
@@ -72,19 +72,21 @@ nav.main-nav .nav-btn {
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 0.25em;
   border-radius: 50px;
   background: #fff;
   box-shadow: 0 0 8px rgb(0 0 0 / 5%);
   letter-spacing: 1px;
   text-transform: uppercase;
-  transition: all 0.5s ease;
+  transition: all 0.3s ease;
+  transform: scale(1);
 }
 
 nav.main-nav .nav-btn:hover {
-  letter-spacing: 2px;
   background: var(--primary);
   color: #fff;
   box-shadow: 0 7px 29px var(--shadow);
+  transform: scale(1.05);
 }
 
 nav.main-nav .nav-btn::after {
@@ -109,6 +111,24 @@ nav.main-nav .nav-btn:hover::after {
 nav.main-nav .nav-btn:active {
   transform: translateY(4px);
   box-shadow: none;
+}
+
+nav.main-nav .nav-btn svg {
+  width: 1.2em;
+  height: 1.2em;
+}
+
+nav.main-nav .nav-btn .label {
+  display: inline;
+}
+
+@media (max-width: 600px) {
+  nav.main-nav .nav-btn {
+    padding: 0.5em;
+  }
+  nav.main-nav .nav-btn .label {
+    display: none;
+  }
 }
 
 nav.main-nav .brand {
@@ -147,10 +167,10 @@ button {
 }
 
 button:hover {
-  letter-spacing: 2px;
   background: var(--primary);
   color: #fff;
   box-shadow: 0 7px 29px var(--shadow);
+  transform: scale(1.05);
 }
 
 button:active {
@@ -183,6 +203,14 @@ td {
 
 .question {
   margin-bottom: 1em;
+}
+
+.review-card {
+  margin-bottom: 1rem;
+  padding: 1rem;
+  border-radius: 6px;
+  background: var(--code-bg);
+  box-shadow: 0 2px 6px rgb(0 0 0 / 10%);
 }
 
 .correct {
@@ -259,7 +287,9 @@ pre {
 .lightbox {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.8);
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -268,6 +298,12 @@ pre {
   padding: 0;
   width: 100%;
   height: 100%;
+}
+.lightbox:hover,
+.lightbox:active {
+  background: rgba(0, 0, 0, 0.6);
+  box-shadow: none;
+  transform: none;
 }
 .lightbox img {
   max-width: 90%;


### PR DESCRIPTION
## Summary
- simplify `app.css` and centralize image-related classes
- remove duplicated `<style>` blocks in pages
- update question pages to use new `.images` and `.thumbs` helpers

## Testing
- `pnpm check`
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877c9cb0e6c832791344b11781a89cf