### PR TITLE
Fix settings auto save

### DIFF
--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,22 +1,7 @@
 <script lang="ts">
   import { dataDir, darkMode } from '$lib/stores/settings';
   import { getQuestionBank } from '$lib/stores/questions';
-  import { history, saveHistory } from '$lib/stores/results';
-
-  let dir = '';
-  $: dir = $dataDir;
-  let dark = $darkMode;
-
-  /**
-   * Persist the input data directory path to the settings store.
-   */
-  function updateDir() {
-    dataDir.set(dir);
-  }
-
-  function updateDark() {
-    darkMode.set(dark);
-  }
+  import { history } from '$lib/stores/results';
 
   /**
    * Download the current question bank as a JSON file.
@@ -48,13 +33,12 @@
 <main>
   <h1>Settings</h1>
   <label>
-    Data Directory <input bind:value={dir} />
+    Data Directory <input bind:value={$dataDir} />
   </label>
-  <button on:click={updateDir}>Save Path</button>
   <button on:click={exportQuestions}>Export Question Bank</button>
   <button on:click={exportHistory}>Export History</button>
   <label>
-    Dark Mode <input type="checkbox" bind:checked={dark} on:change={updateDark} />
+    Dark Mode <input type="checkbox" bind:checked={$darkMode} />
   </label>
 </main>
 


### PR DESCRIPTION
## Summary
- bind settings UI directly to the store so changes persist immediately

## Testing
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_68790331e75c832786e3cb9732dc91ce