### PR TITLE
Optimize grading of multiple-choice answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,30 +11,79 @@ Qastella is a desktop application for managing question banks and running mock e
 - Attach any number of images to a question and keep them in the JSON export
 - Optional dark mode toggle
 
-## Development
+## Installation
 
 1. Install [pnpm](https://pnpm.io/) and the Rust toolchain.
-2. Install dependencies:
-
+2. Install JavaScript dependencies:
    ```bash
    pnpm install
    ```
-
 3. Start the application in development mode:
-
    ```bash
    pnpm tauri dev
    ```
+4. Build a distributable package with:
+   ```bash
+   pnpm tauri build
+   ```
+5. Run `pnpm check` to perform type checking.
 
-4. Run `pnpm check` to perform type checking.
-
-The project uses SvelteKit with adapter-static and Tauri 2. Most of the application logic is contained in the `src` and `src-tauri` folders.
+The project uses SvelteKit with `adapter-static` and Tauri 2. Most of the application logic lives in the `src` and `src-tauri` folders.
 
 ## User Guide
 
-1. **Import Questions** – Navigate to *Import Question Bank* and choose a JSON file using the provided example structure. You can also load a built‑in sample.
-2. **Manage Bank** – The *Question Bank* page lets you edit or delete questions. Remember to click *Save Bank* to persist your changes.
-3. **Add Question** – Use the *Add Question* page to quickly paste text and images when creating new questions.
-4. **Start Exam** – Visit *Mock Exam* to configure the number of questions and start a practice session. After submitting you will see your score.
-5. **Review History** – The *History* page lists past attempts. Click an entry to see detailed answers or delete unwanted records.
-6. **Settings** – Change the data directory, export your questions and history, and toggle dark mode.
+### Importing Questions
+
+- Navigate to **Import Question Bank**.
+- Choose a JSON file using the structure shown below or load the built‑in sample.
+
+### Managing Your Bank
+
+- The **Question Bank** page lists all questions.
+- Edit or delete entries and click **Save Bank** to persist changes.
+
+### Adding Questions
+
+- Use the **Add Question** page to paste text and images when creating new questions.
+- Uploaded images are embedded directly into the JSON export.
+
+### Taking a Mock Exam
+
+- Visit **Mock Exam** to configure how many questions to answer.
+- Answer each question and press **Submit** to see your score.
+
+### Reviewing History
+
+- The **History** page shows previous exam attempts.
+- Click an attempt to view answers or delete unwanted records.
+
+### Settings
+
+- Change the data directory where question banks and history are saved.
+- Export all questions and history as a backup.
+- Toggle dark mode.
+
+## Question Bank Format
+
+A question bank is stored as JSON where questions are grouped by subject and source. Each question object supports optional images and text options.
+
+```json
+{
+  "subjects": {
+    "Biology": {
+      "2024": [
+        {
+          "id": 1,
+          "type": "single",
+          "question": "...",
+          "options": { "A": "...", "B": "..." },
+          "answer": "A",
+          "images": ["data:image/png;base64,..."]
+        }
+      ]
+    }
+  }
+}
+```
+
+The application will automatically convert between this format and the flat list used internally.

--- a/src/routes/mock-exam/+page.svelte
+++ b/src/routes/mock-exam/+page.svelte
@@ -33,10 +33,11 @@
         const ans = answers[q.id] ?? [];
         let ok = false;
         if (Array.isArray(q.answer)) {
+          const set = new Set(ans);
           ok =
             Array.isArray(ans) &&
-            q.answer.length === ans.length &&
-            q.answer.every((a) => ans.includes(a));
+            q.answer.length === set.size &&
+            q.answer.every((a) => set.has(a));
         } else {
           ok = ans[0] === q.answer;
         }

--- a/src/routes/mock-exam/+page.svelte
+++ b/src/routes/mock-exam/+page.svelte
@@ -8,6 +8,11 @@
   // Stores selected answers keyed by question id
   let answers: Record<number, string[]> = {};
 
+  /**
+   * Update the user's selected answer for a question. Multiple choice
+   * questions allow selecting several options, while single choice
+   * questions replace the previous selection.
+   */
   function toggleOption(q: Question, opt: string) {
     const current = answers[q.id] ?? [];
     if (q.type === 'multiple') {
@@ -33,6 +38,8 @@
         const ans = answers[q.id] ?? [];
         let ok = false;
         if (Array.isArray(q.answer)) {
+          // Convert the selected answers to a Set to avoid duplicate
+          // values and speed up membership checks.
           const set = new Set(ans);
           ok =
             Array.isArray(ans) &&


### PR DESCRIPTION
## Summary
- speed up exam result grading by using Set lookup for answers

## Testing
- `pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_687904e198e08327923d4158bc7a3435