### PR TITLE
Improve UI and import handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ A question bank is stored as JSON where questions are grouped by subject and sou
         {
           "id": 1,
           "type": "single",
-          "question": "...",
-          "options": { "A": "...", "B": "..." },
+          "question": "Is the Earth round?",
+          "options": { "A": "Yes", "B": "No" },
           "answer": "A",
           "images": ["data:image/png;base64,..."]
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,7 +47,7 @@ fn sample_questions() -> RQuestionBank {
 
     let question = RQuestion {
         id: 1,
-        question: "Example?".into(),
+        question: "Is the Earth round?".into(),
         options: Some(opts),
         answer: Value::String("A".into()),
         images: None,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { derived } from 'svelte/store';
   import { questions } from '$lib/stores/questions';
-  import { lastResult, attemptCount, correctTotal } from '$lib/stores/results';
+  import { attemptCount, correctTotal } from '$lib/stores/results';
   import { goto } from '$app/navigation';
 
   const accuracy = derived([correctTotal, attemptCount], ([$c, $a]) =>
@@ -16,17 +16,17 @@
     <div>Attempts: {$attemptCount}</div>
     <div>Accuracy: {$accuracy}%</div>
   </section>
-  {#if $lastResult}
-    <section class="recent">
-      <h2>Last Result</h2>
-      <p>
-        Score:
-        {$lastResult.records.filter((r) => r.correct).length} /
-        {$lastResult.records.length}
-      </p>
-      <a class="nav-btn" href="/exam-result">View details</a>
-    </section>
-  {/if}
+  <section class="graphs">
+    <h2>Statistics</h2>
+    <div class="graph-row">
+      <span>Accuracy</span>
+      <progress value={$accuracy} max="100">{$accuracy}%</progress>
+    </div>
+    <div class="graph-row">
+      <span>Attempts</span>
+      <progress value={$attemptCount} max="{$questions.length}"></progress>
+    </div>
+  </section>
   <nav class="quick">
     <button class="nav-btn" type="button" on:click={() => goto('/exam-config')}>Start Mock Exam</button>
     <button class="nav-btn" type="button" on:click={() => goto('/import-questionbank')}>Import Question Bank</button>

--- a/src/routes/add-question/+page.svelte
+++ b/src/routes/add-question/+page.svelte
@@ -103,6 +103,7 @@
     };
     questions.set([...list, q]);
     await saveQuestionBank();
+    console.debug('Added question', id);
     if (redirect) {
       goto('/question-bank');
     } else {

--- a/src/routes/import-questionbank/+page.svelte
+++ b/src/routes/import-questionbank/+page.svelte
@@ -20,6 +20,9 @@
     reader.onload = () => {
       try {
         const raw = JSON.parse(reader.result as string) as QuestionBank;
+        if (!raw || typeof raw !== 'object' || !raw.subjects) {
+          throw new Error('Invalid question bank format');
+        }
         questions.update((existing) => {
           let nextId = Math.max(0, ...existing.map((q) => q.id)) + 1;
           const flat = flattenBank(raw);
@@ -32,7 +35,7 @@
         });
         saveQuestionBank();
       } catch (e) {
-        console.error('Failed to parse', e);
+        console.error('Failed to import', e);
       }
     };
     reader.readAsText(file);
@@ -43,7 +46,10 @@
    */
   async function loadSample() {
     const data = (await invoke('sample_questions')) as QuestionBank;
-    questions.set(flattenBank(data));
+    questions.update((existing) => [
+      ...existing,
+      ...flattenBank(data)
+    ]);
     saveQuestionBank();
   }
 </script>

--- a/src/routes/mock-exam/+page.svelte
+++ b/src/routes/mock-exam/+page.svelte
@@ -75,8 +75,11 @@
     </p>
   {:else}
     <form on:submit|preventDefault={submit}>
-      {#each $examQuestions as q (q.id)}
+      {#each $examQuestions as q, i (q.id)}
         <div class="question review-card" transition:fade>
+          <div class="title-row">
+            <h2>Question {i + 1} / {$examQuestions.length}</h2>
+          </div>
           <p>{q.question}</p>
           {#if q.images}
             <div class="images">

--- a/src/routes/question-bank/+page.svelte
+++ b/src/routes/question-bank/+page.svelte
@@ -96,6 +96,30 @@
     });
   }
 
+  /**
+   * Paste handler to allow images to be pasted directly into the edit dialog.
+   */
+  function handlePaste(e: ClipboardEvent) {
+    if (!editing) return;
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    for (const it of items) {
+      if (it.type.startsWith('image/')) {
+        const f = it.getAsFile();
+        if (f) {
+          const r = new FileReader();
+          r.onload = () => {
+            editing = {
+              ...editing!,
+              images: [...(editing!.images ?? []), r.result as string]
+            };
+          };
+          r.readAsDataURL(f);
+        }
+      }
+    }
+  }
+
   /** Remove an image by index from the current question. */
   function removeImage(i: number) {
     if (!editing || !editing.images) return;
@@ -120,6 +144,7 @@
       }
       return [...list, editing!];
     });
+    console.debug('Saved question', editing.id);
     dlg?.close();
     editing = null;
   }
@@ -191,7 +216,7 @@
   {/if}
 </main>
 
-<dialog bind:this={dlg}>
+<dialog bind:this={dlg} on:paste={handlePaste}>
   {#if editing}
     <h2>Edit Question {editing.id}</h2>
     <label>

--- a/src/routes/review/+page.svelte
+++ b/src/routes/review/+page.svelte
@@ -21,10 +21,12 @@
   {#if $lastResult}
 {#each $lastResult.records as rec, i (rec.question.id)}
       <article class="review-card" transition:fade>
-        <h2>Question {i + 1}</h2>
-        <button type="button" class="copy-btn" on:click={() => copy(rec)}>
-          Copy
-        </button>
+        <div class="title-row">
+          <h2>Question {i + 1}</h2>
+          <button type="button" class="copy-btn" on:click={() => copy(rec)}>
+            Copy
+          </button>
+        </div>
         <p>{rec.question.question}</p>
         {#if rec.question.images}
           <div class="images">

--- a/static/app.css
+++ b/static/app.css
@@ -224,6 +224,12 @@ td {
   background: var(--code-bg);
   box-shadow: 0 2px 6px rgb(0 0 0 / 10%);
 }
+.title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
 
 .correct {
   background: #c8e6c9;
@@ -398,7 +404,7 @@ pre {
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
+  z-index: 2000;
   border: none;
   padding: 0;
   width: 100%;
@@ -438,5 +444,17 @@ pre {
 }
 .dashboard .quick a {
   margin: 0.25em;
+}
+
+.dashboard .graphs {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.dashboard .graph-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- tweak review layout so copy button sits beside the title
- allow pasting images while editing a question and raise lightbox z-index
- validate imported JSON and merge sample questions
- show simple statistics on dashboard
- display question numbers in mock exam
- add debug logs when saving or adding questions
- update sample question and docs

## Testing
- `pnpm install`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_687ba9b1f098832780fc86dd4c531e6d