### PR TITLE
fix: persist question bank changes

### DIFF
--- a/src/lib/stores/questions.ts
+++ b/src/lib/stores/questions.ts
@@ -144,3 +144,24 @@ export async function resetQuestionBank() {
   await saveQuestionBank();
 }
 
+/**
+ * Automatically persist question changes to disk with a short debounce.
+ * This helps prevent data loss if the user navigates away without manually
+ * saving after edits or deletions.
+ */
+if (typeof window !== 'undefined') {
+  let initial = true;
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+  questions.subscribe(() => {
+    if (initial) {
+      initial = false;
+      return;
+    }
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      saveQuestionBank();
+      saveTimer = null;
+    }, 300);
+  });
+}
+

--- a/src/lib/stores/questions.ts
+++ b/src/lib/stores/questions.ts
@@ -41,6 +41,7 @@ export function isValidQuestionBank(data: unknown): data is QuestionBank {
         if (typeof qu.question !== 'string') return false;
         if (
           qu.options !== undefined &&
+          qu.options !== null &&
           (typeof qu.options !== 'object' || Array.isArray(qu.options))
         )
           return false;
@@ -56,7 +57,12 @@ export function isValidQuestionBank(data: unknown): data is QuestionBank {
           !Array.isArray(qu.answer)
         )
           return false;
-        if (qu.images !== undefined && !Array.isArray(qu.images)) return false;
+        if (
+          qu.images !== undefined &&
+          qu.images !== null &&
+          !Array.isArray(qu.images)
+        )
+          return false;
       }
     }
   }
@@ -93,6 +99,8 @@ export function flattenBank(bank: QuestionBank): Question[] {
       for (const q of qs) {
         out.push({
           ...q,
+          options: q.options ?? undefined,
+          images: q.images ?? undefined,
           subject: subject || undefined,
           source: source || undefined
         });

--- a/src/routes/import-questionbank/+page.svelte
+++ b/src/routes/import-questionbank/+page.svelte
@@ -48,10 +48,15 @@
    */
   async function loadSample() {
     const data = (await invoke('sample_questions')) as QuestionBank;
-    questions.update((existing) => [
-      ...existing,
-      ...flattenBank(data)
-    ]);
+    questions.update((existing) => {
+      let nextId = Math.max(0, ...existing.map((q) => q.id)) + 1;
+      const added: Question[] = flattenBank(data).map((q) => ({
+        ...q,
+        id: nextId++,
+        type: q.type ?? 'single'
+      }));
+      return [...existing, ...added];
+    });
     saveQuestionBank();
   }
 </script>

--- a/src/routes/question-bank/+page.svelte
+++ b/src/routes/question-bank/+page.svelte
@@ -150,17 +150,25 @@
   }
 
   /**
-   * Delete a question by id.
+   * Delete a question by id and persist the change immediately.
    */
-  function remove(id: number) {
+  async function remove(id: number) {
     questions.update(list => list.filter(q => q.id !== id));
+    await saveQuestionBank();
   }
 </script>
 
 <main class="bank-page">
   <h1>Question Bank</h1>
   {#if $questions.length === 0}
-    <p>No questions loaded. <a href="/import-questionbank">Import a file</a>.</p>
+    <div class="empty-state">
+      <h2>Your question bank is empty</h2>
+      <p>Start by importing questions or add one manually.</p>
+      <div class="actions">
+        <a href="/import-questionbank">Import Questions</a>
+        <a href="/add-question">Add Question</a>
+      </div>
+    </div>
   {:else}
     <div class="filters">
       <input placeholder="Keyword" bind:value={$keyword} />
@@ -308,6 +316,38 @@
     max-width: 800px;
     margin: 0 auto;
     display: block;
+  }
+  .empty-state {
+    text-align: center;
+    margin-top: 2rem;
+  }
+  .empty-state .actions {
+    margin-top: 1rem;
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+  }
+  .empty-state .actions a {
+    text-decoration: none;
+    padding: 0.6em 1.25em;
+    border-radius: 50px;
+    background: var(--button-bg);
+    color: var(--nav-text);
+    box-shadow: 0 0 8px rgb(0 0 0 / 5%);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    transition: all 0.5s ease;
+  }
+  .empty-state .actions a:hover {
+    background: var(--primary);
+    color: #fff;
+    box-shadow: 0 7px 29px var(--shadow);
+    transform: scale(1.05);
+  }
+  .empty-state .actions a:active {
+    transform: translateY(4px);
+    box-shadow: none;
+    transition: 100ms;
   }
   table.bank {
     width: 70vw;

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
   import { dataDir, darkMode } from '$lib/stores/settings';
-  import { getQuestionBank, resetQuestionBank } from '$lib/stores/questions';
+  import {
+    getQuestionBank,
+    resetQuestionBank,
+    questions,
+    flattenBank,
+    isValidQuestionBank
+  } from '$lib/stores/questions';
   import { history } from '$lib/stores/results';
+  import { invoke } from '@tauri-apps/api/core';
 
   /**
    * Download the current question bank as a JSON file.
@@ -37,6 +44,23 @@
       await resetQuestionBank();
     }
   }
+
+  /**
+   * Reload the question bank from disk if the stored data is valid.
+   */
+  async function reloadBank() {
+    try {
+      const dir = $dataDir || null;
+      const raw = (await invoke('load_questions', { dir })) as unknown;
+      if (!isValidQuestionBank(raw)) {
+        alert('Question bank file is invalid. No changes were loaded.');
+        return;
+      }
+      questions.set(flattenBank(raw));
+    } catch (e) {
+      console.error('Failed to reload question bank', e);
+    }
+  }
 </script>
 
 <main>
@@ -46,6 +70,7 @@
   </label>
   <button on:click={exportQuestions}>Export Question Bank</button>
   <button on:click={exportHistory}>Export History</button>
+  <button on:click={reloadBank}>Reload Question Bank</button>
   <button on:click={resetBank}>Reset Question Bank</button>
   <label>
     Dark Mode <input type="checkbox" bind:checked={$darkMode} />

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -9,6 +9,7 @@
   } from '$lib/stores/questions';
   import { history } from '$lib/stores/results';
   import { invoke } from '@tauri-apps/api/core';
+  import { addToast } from '$lib/stores/toast';
 
   /**
    * Download the current question bank as a JSON file.
@@ -53,7 +54,7 @@
       const dir = $dataDir || null;
       const raw = (await invoke('load_questions', { dir })) as unknown;
       if (!isValidQuestionBank(raw)) {
-        alert('Question bank file is invalid. No changes were loaded.');
+        addToast('Question bank file is invalid. No changes were loaded.');
         return;
       }
       questions.set(flattenBank(raw));


### PR DESCRIPTION
## Summary
- auto-save question bank whenever questions change
- persist deletions immediately from the question bank page
- improve the question bank empty state styling

## Testing
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_68945f6f6144832797c378b6bfc5e11a