### PR TITLE
Refactor question validation and optimize stores

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,7 +130,7 @@ fn save_questions(
         }
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    let data = serde_json::to_vec_pretty(&bank).map_err(|e| e.to_string())?;
+    let data = serde_json::to_vec(&bank).map_err(|e| e.to_string())?;
     fs::write(path, data).map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -164,7 +164,7 @@ fn save_history(
         }
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    let data = serde_json::to_vec_pretty(&history).map_err(|e| e.to_string())?;
+    let data = serde_json::to_vec(&history).map_err(|e| e.to_string())?;
     fs::write(path, data).map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src/routes/exam-config/+page.svelte
+++ b/src/routes/exam-config/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { questions, type Question } from '$lib/stores/questions';
+  import { questions, type Question, subjects, sources } from '$lib/stores/questions';
   import { examQuestions } from '$lib/stores/exam';
   import { goto } from '$app/navigation';
 import { writable, derived, get } from 'svelte/store';
@@ -14,14 +14,6 @@ let shuffleQuestions = true;
 let shuffleOptions = true;
 
   // Distinct list of subjects and sources for the selection lists
-  const subjects = derived(
-    questions,
-    qs => Array.from(new Set(qs.map(q => q.subject).filter(Boolean))) as string[]
-  );
-  const sources = derived(
-    questions,
-    qs => Array.from(new Set(qs.map(q => q.source).filter(Boolean))) as string[]
-  );
 
   // Questions matching the current subject/source filters
   const filtered = derived(

--- a/src/routes/question-bank/+page.svelte
+++ b/src/routes/question-bank/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { questions, type Question, saveQuestionBank } from '$lib/stores/questions';
+  import { questions, type Question, saveQuestionBank, subjects, sources } from '$lib/stores/questions';
 import { writable, derived, type Readable } from 'svelte/store';
 import { fade } from 'svelte/transition';
 
@@ -14,27 +14,7 @@ const debouncedKeyword: Readable<string> = derived(keyword, ($kw, set) => {
   return () => clearTimeout(handle);
 }, '');
 
-// Unique list of subjects for the checkbox filters
-const subjects = derived(
-  questions,
-  (qs) => {
-    const set = new Set<string>();
-    for (const q of qs) {
-      if (q.subject) set.add(q.subject);
-    }
-    return [...set];
-  }
-);
-const sources = derived(
-  questions,
-  (qs) => {
-    const set = new Set<string>();
-    for (const q of qs) {
-      if (q.source) set.add(q.source);
-    }
-    return [...set];
-  }
-);
+// Unique lists of subjects and sources
 
 // Apply all filter inputs and only show results when some filter is active
 const filtered = derived(


### PR DESCRIPTION
## Summary
- modularize question bank validation with helper functions
- centralize subject/source indexing and use writable Map for answers
- use compact JSON serialization for Tauri saves

## Testing
- `pnpm check`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_689764b0b5288327a439608d42787670